### PR TITLE
Allow passing decompressed keys into aggregate verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [dev]
+
+### BREAKING CHANGES
+* Signature.verifyAggregate now takes decompressed pubkeys instead of raw bytes of compressed key
+
 ## [3.0.0] - 2020-07-31
 
 ### BREAKING CHANGES

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ export function verifyAggregate(publicKeys: Uint8Array[], messageHash: Uint8Arra
   try {
     return Signature
       .fromCompressedBytes(signature)
-      .verifyAggregate(publicKeys, messageHash);
+      .verifyAggregate(publicKeys.map(pubkey => PublicKey.fromBytes(pubkey)), messageHash);
   } catch (e) {
     return false;
   }

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -52,9 +52,9 @@ export class Signature {
     return this.value;
   }
 
-  public verifyAggregate(publicKey: Uint8Array[], message: Uint8Array): boolean {
+  public verifyAggregate(publicKeys: PublicKey[], message: Uint8Array): boolean {
     return this.value.fastAggregateVerify(
-      publicKey.map((bytes) => PublicKey.fromBytes(bytes).getValue()),
+      publicKeys.map((key) => key.getValue()),
       message
     );
   }


### PR DESCRIPTION
This allows us to pass already decompressed pubkeys when verifying aggregated signature (attestations) which reduces number of wasm invocations.