### PR TITLE
Define interface for chainsafe/bls

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,0 +1,34 @@
+interface SecretKey {
+  toPublicKey(): PublicKey;
+  sign(msg: Uint8Array): Signature;
+  serialize(): Uint8Array;
+}
+
+interface PublicKey {
+  keyValidate(): void;
+  compress(): Uint8Array;
+  serialize(): Uint8Array;
+}
+
+interface Signature {
+  compress(): Uint8Array;
+  serialize(): Uint8Array;
+}
+
+interface Bls {
+  // Verification
+  verify(msg: Uint8Array, pk: PublicKey, sig: Signature): void;
+  fastAggregateVerify(msg: Uint8Array, pks: PublicKey[], sig: Signature): void;
+  aggregateVerify(msgs: Uint8Array[], pks: PublicKey[], sig: Signature): void;
+  aggregateVerifyMultiple(msgs: Uint8Array[], pks: PublicKey[], sigs: Signature[]): void;
+
+  // Aggregation
+  aggregatePublicKeys(pks: PublicKey[]): PublicKey;
+  aggregateSignatures(sigs: Signature[]): Signature;
+
+  // Deserialization
+  publicKeyFromBytes(bytes: Uint8Array): PublicKey;
+  signatureFromBytes(bytes: Uint8Array): Signature;
+  secretKeyFromBytes(bytes: Uint8Array): SecretKey;
+  secretKeyFromKeygen(ikm: Uint8Array): SecretKey;
+}


### PR DESCRIPTION
In preparation to support both supranational and blst implementations of bls, there must exist a common interface that both wrapped libraries must follow. This interface covers all required functionality while being minimal. It does not require any static class methods which are hard to type with Typescript interfaces.

Note that this interface will cause breaking changes with the current interface