### PR TITLE
Make PublicKey type != Signature type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,8 @@ export declare class PublicKey implements IPublicKey {
   static aggregate(pubkeys: PublicKey[]): PublicKey;
   toBytes(): Uint8Array;
   toHex(): string;
+  // Virtual property so PublicKey type != Signature type
+  private isPublicKey: true; 
 }
 
 export declare class Signature implements ISignature {


### PR DESCRIPTION
This virtual property should not affect any functionality dowstream because it's private, but fools Typescript so if you mistakenly pass a PublicKey class to a function expecting a Signature it won't compile
 
```ts
function withSk(sk: PrivateKey) {}
function withPk(pk: PublicKey) {}
function withSig(sig: Signature) {}

const sk: PrivateKey, pk: PublicKey, sig: Signature

withSk(sk) // only one should be ok
withSk(pk)
withSk(sig)

withPk(sk)
withPk(pk) // only one should be ok
withPk(sig)

withSig(sk)
withSig(pk)
withSig(sig) // only one should be ok
```