### PR TITLE
De-duplicate interface

### DIFF
--- a/src/blst/publicKey.ts
+++ b/src/blst/publicKey.ts
@@ -1,7 +1,7 @@
 import * as blst from "@chainsafe/blst";
 import {EmptyAggregateError, ZeroPublicKeyError} from "../errors";
 import {bytesToHex, hexToBytes} from "../helpers";
-import {IPublicKey} from "../interface";
+import {PublicKey as IPublicKey} from "../interface";
 
 export class PublicKey implements IPublicKey {
   readonly affine: blst.PublicKey;

--- a/src/blst/secretKey.ts
+++ b/src/blst/secretKey.ts
@@ -1,7 +1,7 @@
 import * as blst from "@chainsafe/blst";
 import {bytesToHex, hexToBytes, isZeroUint8Array, randomBytes} from "../helpers";
 import {SECRET_KEY_LENGTH} from "../constants";
-import {ISecretKey} from "../interface";
+import {SecretKey as ISecretKey} from "../interface";
 import {PublicKey} from "./publicKey";
 import {Signature} from "./signature";
 import {ZeroSecretKeyError} from "../errors";

--- a/src/blst/signature.ts
+++ b/src/blst/signature.ts
@@ -1,6 +1,6 @@
 import * as blst from "@chainsafe/blst";
 import {bytesToHex, hexToBytes} from "../helpers";
-import {ISignature} from "../interface";
+import {Signature as ISignature} from "../interface";
 import {PublicKey} from "./publicKey";
 import {EmptyAggregateError, ZeroSignatureError} from "../errors";
 

--- a/src/herumi/publicKey.ts
+++ b/src/herumi/publicKey.ts
@@ -2,7 +2,7 @@ import {PublicKeyType} from "bls-eth-wasm";
 import {getContext} from "./context";
 import {PUBLIC_KEY_LENGTH} from "../constants";
 import {bytesToHex, hexToBytes, isZeroUint8Array} from "../helpers";
-import {IPublicKey} from "../interface";
+import {PublicKey as IPublicKey} from "../interface";
 import {EmptyAggregateError, InvalidLengthError, ZeroPublicKeyError} from "../errors";
 
 export class PublicKey implements IPublicKey {

--- a/src/herumi/secretKey.ts
+++ b/src/herumi/secretKey.ts
@@ -5,7 +5,7 @@ import {getContext} from "./context";
 import {PublicKey} from "./publicKey";
 import {Signature} from "./signature";
 import {bytesToHex, hexToBytes} from "../helpers";
-import {ISecretKey} from "../interface";
+import {SecretKey as ISecretKey} from "../interface";
 import {InvalidLengthError, ZeroSecretKeyError} from "../errors";
 
 export class SecretKey implements ISecretKey {

--- a/src/herumi/signature.ts
+++ b/src/herumi/signature.ts
@@ -3,7 +3,7 @@ import {SignatureType} from "bls-eth-wasm";
 import {getContext} from "./context";
 import {PublicKey} from "./publicKey";
 import {bytesToHex, hexToBytes, isZeroUint8Array} from "../helpers";
-import {ISignature} from "../interface";
+import {Signature as ISignature} from "../interface";
 import {EmptyAggregateError, InvalidLengthError, InvalidOrderError} from "../errors";
 
 export class Signature implements ISignature {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {IBls, ISecretKey, IPublicKey, ISignature} from "./interface";
+import {IBls} from "./interface";
 import {bls as blsHerumi} from "./herumi";
 
 export type Implementation = "herumi" | "blst-native";
@@ -45,32 +45,3 @@ export declare let verify: IBls["verify"];
 export declare let verifyAggregate: IBls["verifyAggregate"];
 export declare let verifyMultiple: IBls["verifyMultiple"];
 export declare let secretKeyToPublicKey: IBls["secretKeyToPublicKey"];
-
-export declare class SecretKey implements ISecretKey {
-  static fromBytes(bytes: Uint8Array): SecretKey;
-  static fromHex(hex: string): SecretKey;
-  static fromKeygen(entropy?: Uint8Array): SecretKey;
-  sign(message: Uint8Array): Signature;
-  toPublicKey(): PublicKey;
-  toBytes(): Uint8Array;
-  toHex(): string;
-}
-
-export declare class PublicKey implements IPublicKey {
-  static fromBytes(bytes: Uint8Array): PublicKey;
-  static fromHex(hex: string): PublicKey;
-  static aggregate(publicKeys: PublicKey[]): PublicKey;
-  toBytes(): Uint8Array;
-  toHex(): string;
-}
-
-export declare class Signature implements ISignature {
-  static fromBytes(bytes: Uint8Array): Signature;
-  static fromHex(hex: string): Signature;
-  static aggregate(signatures: Signature[]): Signature;
-  verify(publicKey: PublicKey, message: Uint8Array): boolean;
-  verifyAggregate(publicKeys: PublicKey[], message: Uint8Array): boolean;
-  verifyMultiple(publicKeys: PublicKey[], messages: Uint8Array[]): boolean;
-  toBytes(): Uint8Array;
-  toHex(): string;
-}

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,18 +1,18 @@
 export interface IBls {
   SecretKey: {
-    fromBytes(bytes: Uint8Array): ISecretKey;
-    fromHex(hex: string): ISecretKey;
-    fromKeygen(ikm?: Uint8Array): ISecretKey;
+    fromBytes(bytes: Uint8Array): SecretKey;
+    fromHex(hex: string): SecretKey;
+    fromKeygen(ikm?: Uint8Array): SecretKey;
   };
   PublicKey: {
-    fromBytes(bytes: Uint8Array): IPublicKey;
-    fromHex(hex: string): IPublicKey;
-    aggregate(publicKeys: IPublicKey[]): IPublicKey;
+    fromBytes(bytes: Uint8Array): PublicKey;
+    fromHex(hex: string): PublicKey;
+    aggregate(publicKeys: PublicKey[]): PublicKey;
   };
   Signature: {
-    fromBytes(bytes: Uint8Array): ISignature;
-    fromHex(hex: string): ISignature;
-    aggregate(signatures: ISignature[]): ISignature;
+    fromBytes(bytes: Uint8Array): Signature;
+    fromHex(hex: string): Signature;
+    aggregate(signatures: Signature[]): Signature;
   };
 
   sign(secretKey: Uint8Array, message: Uint8Array): Uint8Array;
@@ -27,27 +27,36 @@ export interface IBls {
   destroy(): void;
 }
 
+export declare class SecretKey {
+  static fromBytes(bytes: Uint8Array): SecretKey;
+  static fromHex(hex: string): SecretKey;
+  static fromKeygen(entropy?: Uint8Array): SecretKey;
+  sign(message: Uint8Array): Signature;
+  toPublicKey(): PublicKey;
+  toBytes(): Uint8Array;
+  toHex(): string;
+}
+
+export declare class PublicKey {
+  static fromBytes(bytes: Uint8Array): PublicKey;
+  static fromHex(hex: string): PublicKey;
+  static aggregate(publicKeys: PublicKey[]): PublicKey;
+  toBytes(): Uint8Array;
+  toHex(): string;
+}
+
+export declare class Signature {
+  static fromBytes(bytes: Uint8Array): Signature;
+  static fromHex(hex: string): Signature;
+  static aggregate(signatures: Signature[]): Signature;
+  verify(publicKey: PublicKey, message: Uint8Array): boolean;
+  verifyAggregate(publicKeys: PublicKey[], message: Uint8Array): boolean;
+  verifyMultiple(publicKeys: PublicKey[], messages: Uint8Array[]): boolean;
+  toBytes(): Uint8Array;
+  toHex(): string;
+}
+
 export interface IKeypair {
-  publicKey: IPublicKey;
-  secretKey: ISecretKey;
-}
-
-export interface IPublicKey {
-  toBytes(): Uint8Array;
-  toHex(): string;
-}
-
-export interface ISignature {
-  toBytes(): Uint8Array;
-  toHex(): string;
-  verify(publicKey: IPublicKey, message: Uint8Array): boolean;
-  verifyAggregate(publicKeys: IPublicKey[], message: Uint8Array): boolean;
-  verifyMultiple(publicKeys: IPublicKey[], messages: Uint8Array[]): boolean;
-}
-
-export interface ISecretKey {
-  toPublicKey(): IPublicKey;
-  sign(message: Uint8Array): ISignature;
-  toBytes(): Uint8Array;
-  toHex(): string;
+  publicKey: PublicKey;
+  secretKey: SecretKey;
 }

--- a/test/benchmark/index.ts
+++ b/test/benchmark/index.ts
@@ -1,6 +1,6 @@
 import {runBenchmark} from "./runner";
 import {runForAllImplementations} from "../switch";
-import {IPublicKey, ISignature} from "../../src/interface";
+import {PublicKey, Signature} from "../../src/interface";
 import {range, randomMessage} from "../util";
 
 const aggCount = 30;
@@ -9,7 +9,7 @@ const aggCount = 30;
   await runForAllImplementations(async (bls, implementation) => {
     // verify
 
-    await runBenchmark<{pk: IPublicKey; msg: Uint8Array; sig: ISignature}, boolean>({
+    await runBenchmark<{pk: PublicKey; msg: Uint8Array; sig: Signature}, boolean>({
       id: `${implementation} verify`,
 
       prepareTest: () => {
@@ -29,7 +29,7 @@ const aggCount = 30;
 
     // Fast aggregate
 
-    await runBenchmark<{pks: IPublicKey[]; msg: Uint8Array; sig: ISignature}, boolean>({
+    await runBenchmark<{pks: PublicKey[]; msg: Uint8Array; sig: Signature}, boolean>({
       id: `${implementation} verifyAggregate`,
 
       prepareTest: () => {
@@ -56,7 +56,7 @@ const aggCount = 30;
 
     // Aggregate pubkeys
 
-    await runBenchmark<IPublicKey[], void>({
+    await runBenchmark<PublicKey[], void>({
       id: `${implementation} aggregate pubkeys (${aggCount})`,
 
       prepareTest: () => {
@@ -71,7 +71,7 @@ const aggCount = 30;
 
     // Aggregate sigs
 
-    await runBenchmark<ISignature[], void>({
+    await runBenchmark<Signature[], void>({
       id: `${implementation} aggregate signatures (${aggCount})`,
 
       prepareTest: () => {

--- a/test/unit/index-named-exports.test.ts
+++ b/test/unit/index-named-exports.test.ts
@@ -1,9 +1,16 @@
 import {expect} from "chai";
-import {SecretKey, PublicKey, Signature, init} from "../../src";
+import {SecretKey, PublicKey, Signature, init, bls} from "../../src";
 
 describe("index named exports", () => {
   it("Classes and methods should be defined", async () => {
     await init("herumi");
+
+    /**
+     * Sample helper to test argument typing
+     */
+    function verifyHelper(pk: PublicKey, sig: Signature, msg: Uint8Array): boolean {
+      return sig.verify(pk, msg);
+    }
 
     const sk = SecretKey.fromKeygen();
     const msg = new Uint8Array(32);
@@ -12,10 +19,11 @@ describe("index named exports", () => {
     expect(verifyHelper(pk, sig, msg)).to.be.true;
   });
 
-  /**
-   * Sample helper to test argument typing
-   */
-  function verifyHelper(pk: PublicKey, sig: Signature, msg: Uint8Array): boolean {
-    return sig.verify(pk, msg);
-  }
+  it("Make sure exported classes are compatible with interface", () => {
+    const sk: SecretKey = bls.SecretKey.fromKeygen();
+    const pk: PublicKey = sk.toPublicKey();
+    const sig: Signature = sk.sign(new Uint8Array(32));
+    pk;
+    sig;
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": ["src", "test"],
+  "exclude": ["test/benchmark"],
   "compilerOptions": {
     "target": "esnext",
     "module": "commonjs",


### PR DESCRIPTION
Use declared classes in root index as interfaces. With this if you do
```ts
const sk = bls.SecretKey.fromKeygen()
```
`sk` will have type `SecretKey` instead of `ISecretKey`