### PR TITLE
Update noble benchmarks with compression disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,13 @@ Results are in `ops/sec (x times slower)`, where `x times slower` = times slower
 
 | Function - `ops/sec`      | `blst` |   `herumi`   |   `noble`\*   |
 | ------------------------- | :----: | :----------: | :-----------: |
-| `verify`                  | 443.75 | 46.658 (x9)  | 12.355 (x36)  |
+| `verify`                  | 443.75 | 46.658 (x9)  | 38 (x12)      |
 | `verifyAggregate` (30)    | 438.68 | 46.615 (x9)  | 9.8803 (x44)  |
 | `verifyMultiple` (30)     | 35.138 | 3.4332 (x10) | 0.9217 (x38)  |
-| `aggregate` (pubkeys, 30) | 15761  | 2603.5 (x6)  | 42.956 (x366) |
-| `aggregate` (sigs, 30)    | 6587.8 | 1018.7 (x6)  |       -       |
+| `aggregate` (pubkeys, 30) | 15761  | 2603.5 (x6)  | 3171 (x5)     |
+| `aggregate` (sigs, 30)    | 6587.8 | 1018.7 (x6)  | 76  (x86)     |
 
-\*`noble` methods include serialization and deserialization to bytes, which may impact all benchmarks specially `aggregate`.
-\*\* `blst` and `herumi` performed 100 runs each, `noble` 10 runs.
+\* `blst` and `herumi` performed 100 runs each, `noble` 10 runs.
 
 Results from CI run https://github.com/ChainSafe/bls/runs/1488856560?check_suite_focus=true#step:12:13
 


### PR DESCRIPTION
I've pushed an optional support for raw Point handling to noble.

noble verify: 30.272 ops/sec (10 runs)
noble verifyAggregate (30): 24.971 ops/sec (10 runs)
noble verifyMultiple (30): 3.4711 ops/sec (10 runs)
noble aggregate pubkeys (30): 2963.1 ops/sec (10 runs)
noble aggregate sigs (30): 71.843 ops/sec (10 runs)