### PR TITLE
Benchmarks: update noble to use decompressed points.

### DIFF
--- a/benchmark/noble.ts
+++ b/benchmark/noble.ts
@@ -118,4 +118,19 @@ import {aggCount, runsNoble} from "./params";
     },
     runs: runsNoble,
   });
+  
+  await runBenchmark<{sk: Uint8Array; msg: Uint8Array}, void>({
+    id: `noble sign`,
+
+    prepareTest: async () => ({
+     input: {
+       sk: generateRandomSecretKey(),
+       msg: randomMessage(),
+     },
+    }),
+    testRunner: async ({sk, msg}) => {
+     await noble.sign(msg, sk);
+    },
+    runs: runsNoble,
+   });
 })();

--- a/benchmark/noble.ts
+++ b/benchmark/noble.ts
@@ -113,8 +113,8 @@ import {aggCount, runsNoble} from "./params";
         input: await Promise.all(range(aggCount).map(() => noble.PointG2.hashToCurve(generateRandomSecretKey()))),
       };
     },
-    testRunner: async (pks) => {
-      noble.aggregatePublicKeys(pks);
+    testRunner: async (sigs) => {
+      noble.aggregateSignatures(sigs);
     },
     runs: runsNoble,
   });

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -8,6 +8,6 @@
     "benchmark:all": "ts-node index && ts-node noble"
   },
   "dependencies": {
-    "noble-bls12-381": "^0.6.1"
+    "noble-bls12-381": "^0.7.1"
   }
 }

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -8,6 +8,6 @@
     "benchmark:all": "ts-node index && ts-node noble"
   },
   "dependencies": {
-    "noble-bls12-381": "^0.7.1"
+    "noble-bls12-381": "^0.7.2"
   }
 }

--- a/benchmark/runner.ts
+++ b/benchmark/runner.ts
@@ -7,7 +7,7 @@ export async function runBenchmark<T, R>({
   id,
 }: {
   prepareTest: (i: number) => PromiseOptional<{input: T; resultCheck?: (result: R) => boolean}>;
-  testRunner: (input: any) => PromiseOptional<R>;
+  testRunner: (input: T) => PromiseOptional<R>;
   runs?: number;
   id: string;
 }): Promise<void> {

--- a/benchmark/runner.ts
+++ b/benchmark/runner.ts
@@ -7,7 +7,7 @@ export async function runBenchmark<T, R>({
   id,
 }: {
   prepareTest: (i: number) => PromiseOptional<{input: T; resultCheck?: (result: R) => boolean}>;
-  testRunner: (input: T) => PromiseOptional<R>;
+  testRunner: (input: any) => PromiseOptional<R>;
   runs?: number;
   id: string;
 }): Promise<void> {


### PR DESCRIPTION
Much faster now. `verifyMultiple` and `aggregate(pubkeys)` is faster than herumi.

| Function - `ops/sec`      | `blst` |   `herumi`   |   `noble`\*   |
| ------------------------- | :----: | :----------: | :-----------: |
| `verify`                  | 443.75 | 47 (x9)  | 30 (x15)  |
| `verifyAggregate` (30)    | 438.68 | 47 (x9)  | 25 (x18)  |
| `verifyMultiple` (30)     | 35.138 | 3 (x10) | 3.47 (x10)  |
| `aggregate` (pubkeys, 30) | 15761  | 2603 (x6)  | 2963 (x5)   |
| `aggregate` (sigs, 30)    | 6587.8 | 1018.7 (x6)  | 892 (x7)  |