### PR TITLE
Fix silent pass if no spec tests - #1810

### DIFF
--- a/test/switch.ts
+++ b/test/switch.ts
@@ -26,12 +26,18 @@ export async function runForAllImplementations(
 
 export function describeForAllImplementations(callback: (bls: IBls) => void): void {
   runForAllImplementations((bls, implementation) => {
-    describe(implementation, () => {
+    describe(implementation, function () {
       before(async () => {
         await bls.init();
       });
 
-      callback(bls);
+      try {
+        callback(bls);
+      } catch (e) {
+        it("Error generating test cases", function (done) {
+          done(e);
+        });
+      }
     });
   });
 }


### PR DESCRIPTION
Seems like mocha is not propagating errors in second level of test generation. This is a nice hack to prevent script passing and provides clear error message
resolves #1810
