### PR TITLE
Enable worker-threads support for blst

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "randombytes": "^2.1.0"
   },
   "devDependencies": {
-    "@chainsafe/blst": "^0.1.3",
+    "@chainsafe/blst": "^0.1.4",
     "@chainsafe/lodestar-spec-test-util": "^0.12.0",
     "@types/chai": "^4.2.9",
     "@types/mocha": "^8.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -161,10 +161,10 @@
     bls-eth-wasm "^0.4.4"
     randombytes "^2.1.0"
 
-"@chainsafe/blst@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-0.1.3.tgz#b71b1d2cb327fd9654cd22177d5c2e13241bed5d"
-  integrity sha512-JSgXahRRrl6GLcp4sxWDgz/1J1uGesLFRrFCQIPEwH2SpWlNAhReiPkjOLr1Kkxuo5a5YaZVL3ZWMya40WxkKQ==
+"@chainsafe/blst@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-0.1.4.tgz#00156e4a178a5c4aa79559927dece217c284aa6c"
+  integrity sha512-7VyVsNAWNZt0SGe9T0ORKKKziYzJlJw44xxRxdi43j5xCpFTeT/KHG3ZC+kJyzHvDAlVpukEFJoXEjXrkKlFTA==
   dependencies:
     node-fetch "^2.6.1"
     node-gyp "^7.1.2"


### PR DESCRIPTION
`@chainsafe/blst: 0.1.4` fixes:
- Support for worker-threads
- Support for NodeJS 10 on Windows