### PR TITLE
bls-eth-wasm package update for invalidating signature not in g2

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,7 +44,8 @@ module.exports = {
     "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-require-imports": "error",
     "@typescript-eslint/no-unused-vars": ["error", {
-      "varsIgnorePattern": "^_"
+      "varsIgnorePattern": "^_",
+      "argsIgnorePattern": "^_",
     }],
     "@typescript-eslint/ban-ts-ignore": "warn",
     "@typescript-eslint/no-use-before-define": "off",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@chainsafe/bls-keygen": "^0.3.0",
-    "bls-eth-wasm": "^0.4.4",
+    "bls-eth-wasm": "^0.4.8",
     "randombytes": "^2.1.0"
   },
   "devDependencies": {

--- a/src/blst/signature.ts
+++ b/src/blst/signature.ts
@@ -10,7 +10,7 @@ export class Signature extends blst.Signature implements ISignature {
   }
 
   /** @param type Defaults to `CoordType.affine` */
-  static fromBytes(bytes: Uint8Array, type?: blst.CoordType, validate?: boolean): Signature {
+  static fromBytes(bytes: Uint8Array, type?: blst.CoordType, validate = true): Signature {
     const sig = blst.Signature.fromBytes(bytes, type);
     if (validate) sig.sigValidate();
     return new Signature(sig.value);

--- a/src/herumi/signature.ts
+++ b/src/herumi/signature.ts
@@ -2,7 +2,7 @@ import {SignatureType, multiVerify} from "bls-eth-wasm";
 import {getContext} from "./context";
 import {PublicKey} from "./publicKey";
 import {bytesToHex, concatUint8Arrays, hexToBytes, isZeroUint8Array} from "../helpers";
-import {PointFormat, Signature as ISignature} from "../interface";
+import {PointFormat, Signature as ISignature, CoordType} from "../interface";
 import {EmptyAggregateError, InvalidLengthError, InvalidOrderError} from "../errors";
 import {SIGNATURE_LENGTH_COMPRESSED, SIGNATURE_LENGTH_UNCOMPRESSED} from "../constants";
 
@@ -17,7 +17,8 @@ export class Signature implements ISignature {
     this.value = value;
   }
 
-  static fromBytes(bytes: Uint8Array): Signature {
+  static fromBytes(bytes: Uint8Array, _type?: CoordType, validate = true): Signature {
+    if (validate === false) throw new Error("ValidationSkipNotSupported");
     const context = getContext();
     const signature = new context.Signature();
     if (!isZeroUint8Array(bytes)) {

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -14,6 +14,23 @@ export function runIndexTests(bls: IBls): void {
     return {sk, pk, msg, sig};
   }
 
+  describe("signature", () => {
+    it("should fail loading an invalid signature point (not in G2)", () => {
+      /* eslint-disable max-len */
+      const POINT_NOT_IN_G2 = Buffer.from(
+        "8123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "hex"
+      );
+      let sig;
+      try {
+        sig = bls.Signature.fromBytes(POINT_NOT_IN_G2, undefined, true);
+      } catch {
+        /* eslint-disable no-empty */
+      }
+      expect(sig === undefined).to.be.true;
+    });
+  });
+
   describe("verify", () => {
     it("should verify signature", () => {
       const {pk, msg, sig} = getRandomData();

--- a/yarn.lock
+++ b/yarn.lock
@@ -158,7 +158,7 @@
   integrity sha512-WrKcQiFD1GG04OBnWeeb51Gr0ETx9v4n13S+GI24HQx+NeG1A0LfS44zeu3Tp4PGLbU2cziZudlC0WjF3y/HLQ==
   dependencies:
     "@chainsafe/bls-keygen" "^0.3.0"
-    bls-eth-wasm "^0.4.4"
+    bls-eth-wasm "^0.4.8"
     randombytes "^2.1.0"
 
 "@chainsafe/blst@^0.2.0":
@@ -933,10 +933,10 @@ blob@0.0.5:
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.5.tgz#d680eeef25f8cd91ad533f5b01eed48e64caf683"
   integrity sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==
 
-bls-eth-wasm@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/bls-eth-wasm/-/bls-eth-wasm-0.4.4.tgz#3d4c99f8ddee6df23e188dc756125268a0f4d525"
-  integrity sha512-S6XwscKuxxYTANHZX8tZQxZKvj9IhG3aOCEuy1EnNdsAOfuH2pdRIgWrORwpKd4SLdvmPWap9I+TbJRnFx1Yng==
+bls-eth-wasm@^0.4.8:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/bls-eth-wasm/-/bls-eth-wasm-0.4.8.tgz#ad1818fbd1bfb64d8f3e6cd104bd28b96ebaa5f1"
+  integrity sha512-ye7+G6KFLb3i9xSrLASAoYqOUK5WLB6XA5DD8Sh0UQpZ3T999ylsYbFdoOJpmvTDuBuMi23Vy8Jm0pn/GF01CA==
 
 bluebird@^3.3.0, bluebird@^3.5.5:
   version "3.7.2"


### PR DESCRIPTION
1.Earlier, for bls/herumi, the library would accept a point not in G2 as a valid signature. This PR updates the bls-eth-wasm library to 0.4.8 which doesn't accept an invalid signature.
2. Enabled signature validation on as default in bls/blst.
3. Added not in g2 signature test 

