### PR TITLE
Updated code example that has since diverged from implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,24 +22,24 @@ yarn add @chainsafe/bls @chainsafe/blst
 By default, native bindings will be used if in NodeJS and they are installed. A WASM implementation ("herumi") is used as a fallback in case any error occurs.
 
 ```ts
-import {SecretKey, secretKeyToPublicKey, sign, verify} from "@chainsafe/bls";
+import bls, {init} from "@chainsafe/bls/switchable"
 
 (async () => {
-  await init("herumi");
+    await init("herumi");
 
-  // class-based interface
-  const secretKey = SecretKey.fromKeygen();
-  const publicKey = secretKey.toPublicKey();
-  const message = new Uint8Array(32);
+    // class-based interface
+    const secretKey = bls.SecretKey.fromKeygen();
+    const publicKey = secretKey.toPublicKey();
+    const message = new Uint8Array(32);
 
-  const signature = secretKey.sign(message);
-  console.log("Is valid: ", signature.verify(publicKey, message));
+    const signature = secretKey.sign(message);
+    console.log("Is valid: ", signature.verify(publicKey, message));
 
-  // functional interface
-  const sk = secretKey.toBytes();
-  const pk = secretKeyToPublicKey(sk);
-  const sig = sign(sk, message);
-  console.log("Is valid: ", verify(pk, message, sig));
+    // functional interface
+    const sk = secretKey.toBytes();
+    const pk = bls.secretKeyToPublicKey(sk);
+    const sig = bls.sign(sk, message);
+    console.log("Is valid: ", bls.verify(pk, message, sig));
 })();
 ```
 


### PR DESCRIPTION
While upgrading our light_client demo, I noticed that the code samples included in the README no longer compiles. This PR fixes that.