### PR TITLE
Use explicit chai statements

### DIFF
--- a/test/unit/helpers/hex.test.ts
+++ b/test/unit/helpers/hex.test.ts
@@ -14,7 +14,7 @@ describe("helpers / hex", () => {
     it(`${id} hexToBytes`, () => {
       const expectedBytes = hexToBytesNode(hex);
       const bytes = hexToBytes(hex);
-      expect(expectedBytes.equals(bytes)).to.be.true;
+      expect(expectedBytes.equals(bytes)).equals(true);
     });
 
     it(`${id} bytesToHex`, () => {

--- a/test/unit/index-named-exports.test.ts
+++ b/test/unit/index-named-exports.test.ts
@@ -20,7 +20,7 @@ describe("types named exports", async () => {
     const msg = new Uint8Array(32);
     const sig = sk.sign(msg);
     const pk = sk.toPublicKey();
-    expect(verifyHelper(pk, sig, msg)).to.be.true;
+    expect(verifyHelper(pk, sig, msg)).equals(true);
   });
 
   it("Make sure exported classes are compatible with interface", () => {

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -28,7 +28,7 @@ export function runIndexTests(bls: IBls): void {
       } catch {
         /* eslint-disable no-empty */
       }
-      expect(sig === undefined).to.be.true;
+      expect(sig === undefined).equals(true);
     });
   });
 
@@ -37,31 +37,31 @@ export function runIndexTests(bls: IBls): void {
       const {pk, msg, sig} = getRandomData();
       const pkHex = pk.toHex();
       const isValid = bls.verify(pk.toBytes(), msg, sig.toBytes());
-      expect(isValid, "fail verify").to.be.true;
+      expect(isValid, "fail verify").equals(true);
 
       // Make sure to not modify original pubkey when verifying
-      expect(pk.toHex()).to.be.equal(pkHex, "pubkey modified when verifying");
+      expect(pk.toHex()).equals(pkHex, "pubkey modified when verifying");
     });
 
     it("should fail verify empty signature", () => {
       const {pk, msg} = getRandomData();
       const emptySig = Buffer.alloc(96);
       const isValid = bls.verify(pk.toBytes(), msg, emptySig);
-      expect(isValid).to.be.false;
+      expect(isValid).equals(false);
     });
 
     it("should fail verify signature of different message", () => {
       const {pk, sig} = getRandomData();
       const msg2 = randomMessage();
       const isValid = bls.verify(pk.toBytes(), msg2, sig.toBytes());
-      expect(isValid).to.be.false;
+      expect(isValid).equals(false);
     });
 
     it("should fail verify signature signed by different key", () => {
       const {msg, sig} = getRandomData();
       const {pk: pk2} = getRandomData();
       const isValid = bls.verify(pk2.toBytes(), msg, sig.toBytes());
-      expect(isValid).to.be.false;
+      expect(isValid).equals(false);
     });
 
     it("should fail verify empty message", () => {
@@ -87,8 +87,8 @@ export function runIndexTests(bls: IBls): void {
 
       const aggSig = bls.aggregateSignatures(sigs.map((sig) => sig.toBytes()));
 
-      expect(bls.verifyMultiple(aggPubkeys, msgs, aggSig), "should be valid").to.be.true;
-      expect(bls.verifyMultiple(aggPubkeys.reverse(), msgs, aggSig), "should fail - swaped pubkeys").to.be.false;
+      expect(bls.verifyMultiple(aggPubkeys, msgs, aggSig), "should be valid").equals(true);
+      expect(bls.verifyMultiple(aggPubkeys.reverse(), msgs, aggSig), "should fail - swaped pubkeys").equals(false);
     });
 
     it("should verify aggregated signatures - same message", () => {
@@ -105,7 +105,7 @@ export function runIndexTests(bls: IBls): void {
         getN(4, () => msg), // Same message n times
         aggregateSignature
       );
-      expect(isValid).to.be.true;
+      expect(isValid).equals(true);
     });
 
     it("should fail to verify aggregated signatures - no public keys", () => {
@@ -114,7 +114,7 @@ export function runIndexTests(bls: IBls): void {
       const msg2 = randomMessage();
 
       const isValid = bls.verifyMultiple([], [msg2, msg1], sig);
-      expect(isValid).to.be.false;
+      expect(isValid).equals(false);
     });
 
     it("should fail verify empty message", () => {

--- a/test/unit/publicKey.test.ts
+++ b/test/unit/publicKey.test.ts
@@ -7,11 +7,11 @@ export function runPublicKeyTests(bls: IBls): void {
       "0xb6f21199594b56d77670564bf422cb331d5281ca2c1f9a45588a56881d8287ef8619efa6456d6cd2ef61306aa5b21311";
 
     it("should export public key to hex string", () => {
-      expect(bls.PublicKey.fromHex(publicKey).toHex()).to.be.equal(publicKey);
+      expect(bls.PublicKey.fromHex(publicKey).toHex()).equals(publicKey);
     });
 
     it("should export public key to hex string from non-prefixed hex", () => {
-      expect(bls.PublicKey.fromHex(publicKey).toHex()).to.be.equal(publicKey);
+      expect(bls.PublicKey.fromHex(publicKey).toHex()).equals(publicKey);
     });
 
     it("from secret key", () => {

--- a/test/unit/secretKey.test.ts
+++ b/test/unit/secretKey.test.ts
@@ -12,11 +12,11 @@ export function runSecretKeyTests(bls: IBls): void {
     const secretKey = "0x07656fd676da43883d163f49566c72b9cbf0a5a294f26808c807700732456da7";
 
     it("should export secret key to hex string", () => {
-      expect(bls.SecretKey.fromHex(secretKey).toHex()).to.be.equal(secretKey);
+      expect(bls.SecretKey.fromHex(secretKey).toHex()).equals(secretKey);
     });
 
     it("should export secret key to hex string from non-prefixed hex", () => {
-      expect(bls.SecretKey.fromHex(secretKey).toHex()).to.be.equal(secretKey);
+      expect(bls.SecretKey.fromHex(secretKey).toHex()).equals(secretKey);
     });
 
     it("should not accept too short secret key", () => {


### PR DESCRIPTION
Consistent syntax with Lodestar monorepo