### PR TITLE
build(npm): Mark the `@chainsafe/blst` peer dependency as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,5 +120,10 @@
   },
   "peerDependencies": {
     "@chainsafe/blst": "^0.2.4"
+  },
+  "peerDependenciesMeta": {
+    "@chainsafe/blst": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
NPM v7 implemented NPM RFC 0025 [1], which makes it install all peer
dependencies even if users of libraries with peer dependencies haven't
included these peer dependencies in their `package.json` files.

Since we have support for the Herumi backend, the `@chainsafe/blst` lib
shouldn't be a required dependency.

To mark it as optional, we're using the `peerDependenciesMeta` option
introduced by NPM RFC 0030 [2].

[1]: https://github.com/npm/rfcs/blob/main/implemented/0025-install-peer-deps.md
[2]: https://github.com/npm/rfcs/blob/main/implemented/0030-no-install-optional-peer-deps.md
