### PR TITLE
fix: use working autotag action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Create tag
         id: tag
-        uses: butlerlogic/action-autotag@1.1.1
-        with:
+        uses: butlerlogic/action-autotag@1.1.2
+        env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
           strategy: package # Optional, since "package" is the default strategy
           tag_prefix: "v"
     outputs:


### PR DESCRIPTION
`stable` version of [autotag](https://github.com/ButlerLogic/action-autotag/) currently [fails](https://github.com/ButlerLogic/action-autotag/issues/46). Use a pinned version that actually works.

Also remove a warning due to an incorrect usage of `GITHUB_TOKEN`.