### PR TITLE
chore: more support for conditional exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     ".": {
       "import": "./lib/herumi/index.js",
       "node": "./lib/blst-native/index.js",
-      "browser": "./lib/herumi/web.js",
-      "bun": "./lib/herumi/index.js"
+      "browser": "./lib/herumi/web.js"
     },
     "./types": {
       "import": "./lib/types.js"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./lib/herumi/index.js",
-      "node": "./lib/blst-native/index.js",
+      "import": "./lib/index.js",
       "browser": "./lib/herumi/web.js"
     },
     "./types": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./lib/index.js"
+      "import": "./lib/herumi/index.js",
+      "node": "./lib/blst-native/index.js",
+      "browser": "./lib/herumi/web.js",
+      "bun": "./lib/herumi/index.js"
     },
     "./types": {
       "import": "./lib/types.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,6 @@
 import type {IBls} from "./types.js";
 import {getImplementation} from "./getImplementation.js";
 
-// Kept for backward compatibility for tooling that does not support `exports` field in package.json
-
 // Thanks https://github.com/iliakan/detect-node/blob/master/index.esm.js
 const isNode = Object.prototype.toString.call(typeof process !== "undefined" ? process : 0) === "[object process]";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import type {IBls} from "./types.js";
 import {getImplementation} from "./getImplementation.js";
 
+// Kept for backward compatibility for tooling that does not support `exports` field in package.json
+
 // Thanks https://github.com/iliakan/detect-node/blob/master/index.esm.js
 const isNode = Object.prototype.toString.call(typeof process !== "undefined" ? process : 0) === "[object process]";
 


### PR DESCRIPTION
Provide more conditional exports entry points so that there is no need for the current [selection logic](https://github.com/ChainSafe/bls/blob/master/src/index.ts).

This ensures more control on which runtime gets access to which logic (by removing the fragile `node` check) and removes the sometimes problematic top-level await support. Specifically, `bun` now uses `herumi` and not `native`, currently unsupported.