### PR TITLE
chore: Fix blst dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,10 +80,10 @@
   },
   "dependencies": {
     "@chainsafe/bls-keygen": "^0.4.0",
+    "@chainsafe/blst": "^0.2.4",
     "bls-eth-wasm": "^1.1.1"
   },
   "devDependencies": {
-    "@chainsafe/blst": "^0.2.4",
     "@chainsafe/eslint-plugin-node": "^11.2.3",
     "@chainsafe/threads": "^1.9.0",
     "@lodestar/spec-test-util": "1.13.0",


### PR DESCRIPTION
@chainsafe/blst is imported [here](https://github.com/ChainSafe/bls/blob/a16b4dfb6429840cfa9febc1384070d72a42885e/src/blst-native/secretKey.ts#L1) but is listed as a devDependency in `package.json` so causes errors when `@chainsafe/bls` is imported by a consuming application.  