### PR TITLE
feat: implement napi build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Unit tests
         run: yarn test:unit
       - name: Download spec tests
-        run: yarn download-test-cases
+        run: yarn download-spec-tests
       - name: Spec tests
         run: yarn test:spec
       - name: Web tests

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "karma-spec-reporter": "^0.0.32",
     "karma-webpack": "^5.0.0",
     "mocha": "^10.0.0",
+    "null-loader": "^4.0.1",
     "nyc": "^15.0.0",
     "prettier": "^2.1.2",
     "resolve-typescript-plugin": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/bls",
-  "version": "7.2.0",
+  "version": "8.0.0",
   "description": "Implementation of bls signature verification for ethereum 2.0",
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "bls-eth-wasm": "^1.1.1"
   },
   "devDependencies": {
-    "@chainsafe/blst": "^0.2.4",
+    "@chainsafe/blst": "^1.0.0",
     "@chainsafe/eslint-plugin-node": "^11.2.3",
     "@chainsafe/threads": "^1.9.0",
     "@lodestar/spec-test-util": "1.13.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "test:coverage": "nyc --cache-dir .nyc_output/.cache -r lcov -e .ts mocha 'test/unit/**/*.test.ts' && nyc report",
     "test:spec": "mocha 'test/spec/**/*.test.ts'",
     "test": "yarn run test:unit && yarn run test:spec",
-    "download-test-cases": "node --loader ts-node/esm test/downloadSpecTests.ts",
+    "download-spec-tests": "node --loader ts-node/esm test/downloadSpecTests.ts",
     "coverage": "codecov -F bls",
     "benchmark": "node --loader ts-node/esm benchmark/index.ts",
     "benchmark:all": "cd benchmark && yarn install && yarn benchmark:all"
@@ -120,7 +120,7 @@
     "v8-profiler-next": "1.10.0"
   },
   "peerDependencies": {
-    "@chainsafe/blst": "^0.2.4"
+    "@chainsafe/blst": "^1.0.0"
   },
   "peerDependenciesMeta": {
     "@chainsafe/blst": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/bls",
-  "version": "7.1.3",
+  "version": "7.2.0",
   "description": "Implementation of bls signature verification for ethereum 2.0",
   "engines": {
     "node": ">=18"

--- a/src/blst-native/index.ts
+++ b/src/blst-native/index.ts
@@ -1,19 +1,20 @@
 import {SecretKey} from "./secretKey.js";
 import {PublicKey} from "./publicKey.js";
 import {Signature} from "./signature.js";
-import {IBls} from "../types.js";
+import {IBls, Implementation} from "../types.js";
 import {functionalInterfaceFactory} from "../functional.js";
 export * from "../constants.js";
 
 export {SecretKey, PublicKey, Signature};
 
+const implementation: Implementation = "blst-native";
 export const bls: IBls = {
-  implementation: "blst-native",
+  implementation,
   SecretKey,
   PublicKey,
   Signature,
 
-  ...functionalInterfaceFactory({SecretKey, PublicKey, Signature}),
+  ...functionalInterfaceFactory({implementation, SecretKey, PublicKey, Signature}),
 };
 
 export default bls;

--- a/src/blst-native/publicKey.ts
+++ b/src/blst-native/publicKey.ts
@@ -1,16 +1,14 @@
-import * as blst from "@chainsafe/blst";
+import blst from "@chainsafe/blst";
 import {EmptyAggregateError} from "../errors.js";
 import {bytesToHex, hexToBytes} from "../helpers/index.js";
-import {PointFormat, PublicKey as IPublicKey} from "../types.js";
+import {CoordType, PointFormat, PublicKey as IPublicKey} from "../types.js";
 
-export class PublicKey extends blst.PublicKey implements IPublicKey {
-  constructor(value: ConstructorParameters<typeof blst.PublicKey>[0]) {
-    super(value);
-  }
+export class PublicKey implements IPublicKey {
+  private constructor(private readonly key: blst.PublicKey) {}
 
   /** @param type Defaults to `CoordType.jacobian` */
-  static fromBytes(bytes: Uint8Array, type?: blst.CoordType, validate?: boolean): PublicKey {
-    const pk = blst.PublicKey.fromBytes(bytes, type);
+  static fromBytes(bytes: Uint8Array, type?: CoordType, validate?: boolean): PublicKey {
+    const pk = blst.PublicKey.deserialize(bytes, (type as unknown) as blst.CoordType);
     if (validate) pk.keyValidate();
     return new PublicKey(pk.value);
   }
@@ -38,5 +36,9 @@ export class PublicKey extends blst.PublicKey implements IPublicKey {
 
   toHex(format?: PointFormat): string {
     return bytesToHex(this.toBytes(format));
+  }
+
+  multiplyBy(bytes: Uint8Array): PublicKey {
+    return new PublicKey(this.value.multiplyBy(bytes));
   }
 }

--- a/src/blst-native/publicKey.ts
+++ b/src/blst-native/publicKey.ts
@@ -7,7 +7,7 @@ export class PublicKey implements IPublicKey {
   private constructor(private readonly value: blst.PublicKey) {}
 
   /** @param type Defaults to `CoordType.jacobian` */
-  static fromBytes(bytes: Uint8Array, type?: CoordType, validate?: boolean): PublicKey {
+  static fromBytes(bytes: Uint8Array, type?: CoordType, validate = true): PublicKey {
     // need to hack the CoordType so @chainsafe/blst is not a required dep
     const pk = blst.PublicKey.deserialize(bytes, (type as unknown) as blst.CoordType);
     if (validate) pk.keyValidate();

--- a/src/blst-native/secretKey.ts
+++ b/src/blst-native/secretKey.ts
@@ -1,4 +1,4 @@
-import * as blst from "@chainsafe/blst";
+import blst from "@chainsafe/blst";
 import crypto from "crypto";
 import {bytesToHex, hexToBytes, isZeroUint8Array} from "../helpers/index.js";
 import {SECRET_KEY_LENGTH} from "../constants.js";
@@ -9,7 +9,7 @@ import {ZeroSecretKeyError} from "../errors.js";
 
 export class SecretKey implements ISecretKey {
   readonly value: blst.SecretKey;
-  constructor(value: blst.SecretKey) {
+  private constructor(value: blst.SecretKey) {
     this.value = value;
   }
 
@@ -19,7 +19,7 @@ export class SecretKey implements ISecretKey {
       throw new ZeroSecretKeyError();
     }
 
-    const sk = blst.SecretKey.fromBytes(bytes);
+    const sk = blst.SecretKey.deserialize(bytes);
     return new SecretKey(sk);
   }
 
@@ -33,7 +33,7 @@ export class SecretKey implements ISecretKey {
   }
 
   sign(message: Uint8Array): Signature {
-    return new Signature(this.value.sign(message).value);
+    return new Signature(this.value.sign(message));
   }
 
   toPublicKey(): PublicKey {

--- a/src/blst-native/secretKey.ts
+++ b/src/blst-native/secretKey.ts
@@ -8,10 +8,7 @@ import {Signature} from "./signature.js";
 import {ZeroSecretKeyError} from "../errors.js";
 
 export class SecretKey implements ISecretKey {
-  readonly value: blst.SecretKey;
-  private constructor(value: blst.SecretKey) {
-    this.value = value;
-  }
+  constructor(private readonly value: blst.SecretKey) {}
 
   static fromBytes(bytes: Uint8Array): SecretKey {
     // draft-irtf-cfrg-bls-signature-04 does not allow SK == 0
@@ -33,16 +30,18 @@ export class SecretKey implements ISecretKey {
   }
 
   sign(message: Uint8Array): Signature {
-    return new Signature(this.value.sign(message));
+    // @ts-expect-error Need to hack private constructor with static method
+    return Signature.friendBuild(this.value.sign(message));
   }
 
   toPublicKey(): PublicKey {
     const pk = this.value.toPublicKey();
-    return new PublicKey(pk.value);
+    // @ts-expect-error Need to hack private constructor with static method
+    return PublicKey.friendBuild(pk);
   }
 
   toBytes(): Uint8Array {
-    return this.value.toBytes();
+    return this.value.serialize();
   }
 
   toHex(): string {

--- a/src/blst-native/signature.ts
+++ b/src/blst-native/signature.ts
@@ -1,16 +1,16 @@
-import * as blst from "@chainsafe/blst";
+import blst from "@chainsafe/blst";
 import {bytesToHex, hexToBytes} from "../helpers/index.js";
-import {PointFormat, Signature as ISignature} from "../types.js";
+import {CoordType, PointFormat, Signature as ISignature} from "../types.js";
 import {PublicKey} from "./publicKey.js";
 import {EmptyAggregateError, ZeroSignatureError} from "../errors.js";
 
-export class Signature extends blst.Signature implements ISignature {
-  constructor(value: ConstructorParameters<typeof blst.Signature>[0]) {
+export class Signature implements ISignature {
+  private constructor(value: ConstructorParameters<typeof blst.Signature>[0]) {
     super(value);
   }
 
   /** @param type Defaults to `CoordType.affine` */
-  static fromBytes(bytes: Uint8Array, type?: blst.CoordType, validate = true): Signature {
+  static fromBytes(bytes: Uint8Array, type?: CoordType, validate = true): Signature {
     const sig = blst.Signature.fromBytes(bytes, type);
     if (validate) sig.sigValidate();
     return new Signature(sig.value);
@@ -62,6 +62,10 @@ export class Signature extends blst.Signature implements ISignature {
 
   toHex(format?: PointFormat): string {
     return bytesToHex(this.toBytes(format));
+  }
+
+  multiplyBy(bytes: Uint8Array): Signature {
+    return new Signature(this.value.multiplyBy(bytes));
   }
 
   private aggregateVerify(msgs: Uint8Array[], pks: blst.PublicKey[]): boolean {

--- a/src/blst-native/signature.ts
+++ b/src/blst-native/signature.ts
@@ -5,15 +5,14 @@ import {PublicKey} from "./publicKey.js";
 import {EmptyAggregateError, ZeroSignatureError} from "../errors.js";
 
 export class Signature implements ISignature {
-  private constructor(value: ConstructorParameters<typeof blst.Signature>[0]) {
-    super(value);
-  }
+  private constructor(private readonly value: blst.Signature) {}
 
   /** @param type Defaults to `CoordType.affine` */
   static fromBytes(bytes: Uint8Array, type?: CoordType, validate = true): Signature {
-    const sig = blst.Signature.fromBytes(bytes, type);
+    // need to hack the CoordType so @chainsafe/blst is not a required dep
+    const sig = blst.Signature.deserialize(bytes, (type as unknown) as blst.CoordType);
     if (validate) sig.sigValidate();
-    return new Signature(sig.value);
+    return new Signature(sig);
   }
 
   static fromHex(hex: string): Signature {
@@ -25,38 +24,56 @@ export class Signature implements ISignature {
       throw new EmptyAggregateError();
     }
 
-    const agg = blst.aggregateSignatures(signatures);
-    return new Signature(agg.value);
+    const agg = blst.aggregateSignatures(signatures.map(({value}) => value));
+    return new Signature(agg);
   }
 
   static verifyMultipleSignatures(sets: {publicKey: PublicKey; message: Uint8Array; signature: Signature}[]): boolean {
     return blst.verifyMultipleAggregateSignatures(
-      sets.map((s) => ({msg: s.message, pk: s.publicKey, sig: s.signature}))
+      // @ts-expect-error Need to hack type to get access to the private `value`
+      sets.map((s) => ({message: s.message, publicKey: s.publicKey.value, signature: s.signature.value}))
     );
+  }
+
+  /**
+   * Implemented for SecretKey to be able to call .sign()
+   */
+  private static friendBuild(sig: blst.Signature): Signature {
+    return new Signature(sig);
   }
 
   verify(publicKey: PublicKey, message: Uint8Array): boolean {
     // Individual infinity signatures are NOT okay. Aggregated signatures MAY be infinity
-    if (this.value.is_inf()) {
+    if (this.value.isInfinity()) {
       throw new ZeroSignatureError();
     }
 
-    return blst.verify(message, publicKey, this);
+    // @ts-expect-error Need to hack type to get access to the private `value`
+    return blst.verify(message, publicKey.value, this.value);
   }
 
   verifyAggregate(publicKeys: PublicKey[], message: Uint8Array): boolean {
-    return blst.fastAggregateVerify(message, publicKeys, this);
+    return blst.fastAggregateVerify(
+      message,
+      // @ts-expect-error Need to hack type to get access to the private `value`
+      publicKeys.map((pk) => pk.value),
+      this.value
+    );
   }
 
   verifyMultiple(publicKeys: PublicKey[], messages: Uint8Array[]): boolean {
-    return blst.aggregateVerify(messages, publicKeys, this);
+    return this.aggregateVerify(
+      messages,
+      // @ts-expect-error Need to hack type to get access to the private `value`
+      publicKeys.map((pk) => pk.value)
+    );
   }
 
   toBytes(format?: PointFormat): Uint8Array {
     if (format === PointFormat.uncompressed) {
-      return this.value.serialize();
+      return this.value.serialize(false);
     } else {
-      return this.value.compress();
+      return this.value.serialize(true);
     }
   }
 
@@ -72,10 +89,10 @@ export class Signature implements ISignature {
     // If this set is simply an infinity signature and infinity publicKey then skip verification.
     // This has the effect of always declaring that this sig/publicKey combination is valid.
     // for Eth2.0 specs tests
-    if (this.value.is_inf() && pks.length === 1 && pks[0].value.is_inf()) {
+    if (this.value.isInfinity() && pks.length === 1 && pks[0].isInfinity()) {
       return true;
     }
 
-    return blst.aggregateVerify(msgs, pks, this);
+    return blst.aggregateVerify(msgs, pks, this.value);
   }
 }

--- a/src/functional.ts
+++ b/src/functional.ts
@@ -1,4 +1,4 @@
-import {IBls} from "./types.js";
+import {IBls, PublicKey, PublicKeyArg, Signature, SignatureArg, SignatureSet} from "./types.js";
 import {validateBytes} from "./helpers/index.js";
 import {NotInitializedError} from "./errors.js";
 
@@ -26,7 +26,7 @@ export function functionalInterfaceFactory({
    * Compines all given signature into one.
    * @param signatures
    */
-  function aggregateSignatures(signatures: Uint8Array[]): Uint8Array {
+  function aggregateSignatures(signatures: SignatureArg[]): Uint8Array {
     const agg = Signature.aggregate(signatures.map((p) => Signature.fromBytes(p)));
     return agg.toBytes();
   }
@@ -35,7 +35,7 @@ export function functionalInterfaceFactory({
    * Combines all given public keys into single one
    * @param publicKeys
    */
-  function aggregatePublicKeys(publicKeys: Uint8Array[]): Uint8Array {
+  function aggregatePublicKeys(publicKeys: PublicKeyArg[]): Uint8Array {
     const agg = PublicKey.aggregate(publicKeys.map((p) => PublicKey.fromBytes(p)));
     return agg.toBytes();
   }
@@ -46,13 +46,27 @@ export function functionalInterfaceFactory({
    * @param message
    * @param signature
    */
-  function verify(publicKey: Uint8Array, message: Uint8Array, signature: Uint8Array): boolean {
-    validateBytes(publicKey, "publicKey");
-    validateBytes(message, "message");
-    validateBytes(signature, "signature");
-
+  function verify(publicKey: PublicKeyArg, message: Uint8Array, signature: SignatureArg): boolean {
     try {
-      return Signature.fromBytes(signature).verify(PublicKey.fromBytes(publicKey), message);
+      validateBytes(message, "message");
+
+      let pk: PublicKey;
+      if (publicKey instanceof Uint8Array) {
+        validateBytes(publicKey, "publicKey");
+        pk = PublicKey.fromBytes(publicKey);
+      } else {
+        pk = publicKey;
+      }
+
+      let sig: Signature;
+      if (signature instanceof Uint8Array) {
+        validateBytes(signature, "signature");
+        sig = Signature.fromBytes(signature);
+      } else {
+        sig = signature;
+      }
+
+      return sig.verify(pk, message);
     } catch (e) {
       if (e instanceof NotInitializedError) throw e;
       return false;
@@ -65,16 +79,29 @@ export function functionalInterfaceFactory({
    * @param message
    * @param signature
    */
-  function verifyAggregate(publicKeys: Uint8Array[], message: Uint8Array, signature: Uint8Array): boolean {
-    validateBytes(publicKeys, "publicKey");
-    validateBytes(message, "message");
-    validateBytes(signature, "signature");
-
+  function verifyAggregate(publicKeys: PublicKeyArg[], message: Uint8Array, signature: SignatureArg): boolean {
     try {
-      return Signature.fromBytes(signature).verifyAggregate(
-        publicKeys.map((publicKey) => PublicKey.fromBytes(publicKey)),
-        message
-      );
+      validateBytes(message, "message");
+
+      const pks: PublicKey[] = [];
+      for (const pk of publicKeys) {
+        if (pk instanceof Uint8Array) {
+          validateBytes(pk, "publicKey");
+          pks.push(PublicKey.fromBytes(pk));
+        } else {
+          pks.push(pk);
+        }
+      }
+
+      let sig: Signature;
+      if (signature instanceof Uint8Array) {
+        validateBytes(signature, "signature");
+        sig = Signature.fromBytes(signature);
+      } else {
+        sig = signature;
+      }
+
+      return sig.verifyAggregate(pks, message);
     } catch (e) {
       if (e instanceof NotInitializedError) throw e;
       return false;
@@ -88,19 +115,33 @@ export function functionalInterfaceFactory({
    * @param signature
    * @param fast Check if all messages are different
    */
-  function verifyMultiple(publicKeys: Uint8Array[], messages: Uint8Array[], signature: Uint8Array): boolean {
-    validateBytes(publicKeys, "publicKey");
-    validateBytes(messages, "message");
-    validateBytes(signature, "signature");
-
+  function verifyMultiple(publicKeys: PublicKeyArg[], messages: Uint8Array[], signature: SignatureArg): boolean {
     if (publicKeys.length === 0 || publicKeys.length != messages.length) {
       return false;
     }
+
     try {
-      return Signature.fromBytes(signature).verifyMultiple(
-        publicKeys.map((publicKey) => PublicKey.fromBytes(publicKey)),
-        messages.map((msg) => msg)
-      );
+      validateBytes(messages, "message");
+
+      const pks: PublicKey[] = [];
+      for (const pk of publicKeys) {
+        if (pk instanceof Uint8Array) {
+          validateBytes(pk, "publicKey");
+          pks.push(PublicKey.fromBytes(pk));
+        } else {
+          pks.push(pk);
+        }
+      }
+
+      let sig: Signature;
+      if (signature instanceof Uint8Array) {
+        validateBytes(signature, "signature");
+        sig = Signature.fromBytes(signature);
+      } else {
+        sig = signature;
+      }
+
+      return sig.verifyMultiple(pks, messages);
     } catch (e) {
       if (e instanceof NotInitializedError) throw e;
       return false;
@@ -117,17 +158,15 @@ export function functionalInterfaceFactory({
    * verify on its own but will if it's added to a specific predictable signature
    * https://ethresear.ch/t/fast-verification-of-multiple-bls-signatures/5407
    */
-  function verifyMultipleSignatures(
-    sets: {publicKey: Uint8Array; message: Uint8Array; signature: Uint8Array}[]
-  ): boolean {
+  function verifyMultipleSignatures(sets: SignatureSet[]): boolean {
     if (!sets) throw Error("sets is null or undefined");
 
     try {
       return Signature.verifyMultipleSignatures(
         sets.map((s) => ({
-          publicKey: PublicKey.fromBytes(s.publicKey),
+          publicKey: s.publicKey instanceof Uint8Array ? PublicKey.fromBytes(s.publicKey) : s.publicKey,
           message: s.message,
-          signature: Signature.fromBytes(s.signature),
+          signature: s.signature instanceof Uint8Array ? Signature.fromBytes(s.signature) : s.signature,
         }))
       );
     } catch (e) {
@@ -135,6 +174,51 @@ export function functionalInterfaceFactory({
       return false;
     }
   }
+
+  /**
+   * Verifies if signature is message signed with given public key.
+   * @param publicKey
+   * @param message
+   * @param signature
+   */
+  async function asyncVerify(message: Uint8Array, publicKey: PublicKeyArg, signature: SignatureArg): Promise<boolean> {}
+
+  /**
+   * Verifies if aggregated signature is same message signed with given public keys.
+   * @param publicKeys
+   * @param message
+   * @param signature
+   */
+  async function asyncVerifyAggregate(
+    message: Uint8Array,
+    publicKeys: PublicKeyArg[],
+    signature: SignatureArg
+  ): Promise<boolean> {}
+
+  /**
+   * Verifies if signature is list of message signed with corresponding public key.
+   * @param publicKeys
+   * @param messages
+   * @param signature
+   * @param fast Check if all messages are different
+   */
+  async function asyncVerifyMultiple(
+    messages: Uint8Array[],
+    publicKeys: PublicKeyArg[],
+    signature: SignatureArg
+  ): Promise<boolean> {}
+
+  /**
+   * Verifies multiple signatures at once returning true if all valid or false
+   * if at least one is not. Optimization useful when knowing which signature is
+   * wrong is not relevant, i.e. verifying an entire Eth2.0 block.
+   *
+   * This method provides a safe way to do so by multiplying each signature by
+   * a random number so an attacker cannot craft a malicious signature that won't
+   * verify on its own but will if it's added to a specific predictable signature
+   * https://ethresear.ch/t/fast-verification-of-multiple-bls-signatures/5407
+   */
+  async function asyncVerifyMultipleSignatures(sets: SignatureSet[]): Promise<boolean> {}
 
   /**
    * Computes a public key from a secret key

--- a/src/functional.ts
+++ b/src/functional.ts
@@ -14,8 +14,6 @@ export function functionalInterfaceFactory({
 }: Pick<IBls, "implementation" | "SecretKey" | "PublicKey" | "Signature">) {
   /**
    * Signs given message using secret key.
-   * @param secretKey
-   * @param message
    */
   function sign(secretKey: Uint8Array, message: Uint8Array): Uint8Array {
     validateBytes(secretKey, "secretKey");
@@ -26,7 +24,6 @@ export function functionalInterfaceFactory({
 
   /**
    * Compines all given signature into one.
-   * @param signatures
    */
   function aggregateSignatures(signatures: SignatureArg[]): Uint8Array {
     const agg = Signature.aggregate(
@@ -37,7 +34,6 @@ export function functionalInterfaceFactory({
 
   /**
    * Combines all given public keys into single one
-   * @param publicKeys
    */
   function aggregatePublicKeys(publicKeys: PublicKeyArg[]): Uint8Array {
     const agg = PublicKey.aggregate(publicKeys.map((pk) => (pk instanceof Uint8Array ? PublicKey.fromBytes(pk) : pk)));
@@ -46,9 +42,6 @@ export function functionalInterfaceFactory({
 
   /**
    * Verifies if signature is message signed with given public key.
-   * @param publicKey
-   * @param message
-   * @param signature
    */
   function verify(publicKey: PublicKeyArg, message: Uint8Array, signature: SignatureArg): boolean {
     try {
@@ -79,9 +72,6 @@ export function functionalInterfaceFactory({
 
   /**
    * Verifies if aggregated signature is same message signed with given public keys.
-   * @param publicKeys
-   * @param message
-   * @param signature
    */
   function verifyAggregate(publicKeys: PublicKeyArg[], message: Uint8Array, signature: SignatureArg): boolean {
     try {
@@ -114,10 +104,6 @@ export function functionalInterfaceFactory({
 
   /**
    * Verifies if signature is list of message signed with corresponding public key.
-   * @param publicKeys
-   * @param messages
-   * @param signature
-   * @param fast Check if all messages are different
    */
   function verifyMultiple(publicKeys: PublicKeyArg[], messages: Uint8Array[], signature: SignatureArg): boolean {
     if (publicKeys.length === 0 || publicKeys.length != messages.length) {
@@ -191,9 +177,6 @@ export function functionalInterfaceFactory({
 
   /**
    * Verifies if signature is message signed with given public key.
-   * @param publicKey
-   * @param message
-   * @param signature
    */
   async function asyncVerify(publicKey: PublicKeyArg, message: Uint8Array, signature: SignatureArg): Promise<boolean> {
     if (implementation === "herumi") return verify(publicKey, message, signature);
@@ -206,9 +189,6 @@ export function functionalInterfaceFactory({
 
   /**
    * Verifies if aggregated signature is same message signed with given public keys.
-   * @param publicKeys
-   * @param message
-   * @param signature
    */
   async function asyncVerifyAggregate(
     publicKeys: PublicKeyArg[],
@@ -229,10 +209,6 @@ export function functionalInterfaceFactory({
 
   /**
    * Verifies if signature is list of message signed with corresponding public key.
-   * @param publicKeys
-   * @param messages
-   * @param signature
-   * @param fast Check if all messages are different
    */
   async function asyncVerifyMultiple(
     publicKeys: PublicKeyArg[],

--- a/src/functional.ts
+++ b/src/functional.ts
@@ -29,7 +29,9 @@ export function functionalInterfaceFactory({
    * @param signatures
    */
   function aggregateSignatures(signatures: SignatureArg[]): Uint8Array {
-    const agg = Signature.aggregate(signatures.map((p) => Signature.fromBytes(p)));
+    const agg = Signature.aggregate(
+      signatures.map((sig) => (sig instanceof Uint8Array ? Signature.fromBytes(sig) : sig))
+    );
     return agg.toBytes();
   }
 
@@ -38,7 +40,7 @@ export function functionalInterfaceFactory({
    * @param publicKeys
    */
   function aggregatePublicKeys(publicKeys: PublicKeyArg[]): Uint8Array {
-    const agg = PublicKey.aggregate(publicKeys.map((p) => PublicKey.fromBytes(p)));
+    const agg = PublicKey.aggregate(publicKeys.map((pk) => (pk instanceof Uint8Array ? PublicKey.fromBytes(pk) : pk)));
     return agg.toBytes();
   }
 

--- a/src/functional.ts
+++ b/src/functional.ts
@@ -165,16 +165,6 @@ export function functionalInterfaceFactory({
     }
   }
 
-  function convertToBlstPublicKeyArg(publicKey: PublicKeyArg): blst.PublicKeyArg {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return publicKey instanceof PublicKey ? ((publicKey as any).value as blst.PublicKey) : publicKey;
-  }
-
-  function convertToBlstSignatureArg(signature: SignatureArg): blst.SignatureArg {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return signature instanceof Signature ? ((signature as any).value as blst.Signature) : signature;
-  }
-
   /**
    * Verifies if signature is message signed with given public key.
    */
@@ -258,6 +248,16 @@ export function functionalInterfaceFactory({
   function secretKeyToPublicKey(secretKey: Uint8Array): Uint8Array {
     validateBytes(secretKey, "secretKey");
     return SecretKey.fromBytes(secretKey).toPublicKey().toBytes();
+  }
+
+  function convertToBlstPublicKeyArg(publicKey: PublicKeyArg): blst.PublicKeyArg {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return publicKey instanceof PublicKey ? ((publicKey as any).value as blst.PublicKey) : publicKey;
+  }
+
+  function convertToBlstSignatureArg(signature: SignatureArg): blst.SignatureArg {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return signature instanceof Signature ? ((signature as any).value as blst.Signature) : signature;
   }
 
   return {

--- a/src/herumi/context.ts
+++ b/src/herumi/context.ts
@@ -21,6 +21,7 @@ export async function setupBls(): Promise<void> {
     if (typeof window === "object") {
       const crypto = window.crypto || window.msCrypto;
       // getRandomValues is not typed in `bls-eth-wasm` because it's not meant to be exposed
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       bls.getRandomValues = (x) => crypto.getRandomValues(x);
     }

--- a/src/herumi/index.ts
+++ b/src/herumi/index.ts
@@ -2,7 +2,7 @@ import {SecretKey} from "./secretKey.js";
 import {PublicKey} from "./publicKey.js";
 import {Signature} from "./signature.js";
 import {init, destroy} from "./context.js";
-import {IBls} from "../types.js";
+import {IBls, Implementation} from "../types.js";
 import {functionalInterfaceFactory} from "../functional.js";
 
 await init();
@@ -11,13 +11,14 @@ export * from "../constants.js";
 
 export {SecretKey, PublicKey, Signature, init, destroy};
 
+const implementation: Implementation = "herumi";
 export const bls: IBls = {
-  implementation: "herumi",
+  implementation,
   SecretKey,
   PublicKey,
   Signature,
 
-  ...functionalInterfaceFactory({SecretKey, PublicKey, Signature}),
+  ...functionalInterfaceFactory({implementation, SecretKey, PublicKey, Signature}),
 };
 
 export default bls;

--- a/src/herumi/publicKey.ts
+++ b/src/herumi/publicKey.ts
@@ -58,4 +58,13 @@ export class PublicKey implements IPublicKey {
   toHex(format?: PointFormat): string {
     return bytesToHex(this.toBytes(format));
   }
+
+  multiplyBy(_bytes: Uint8Array): PublicKey {
+    // TODO: I found this in the code but its not exported. Need to figure out
+    //       how to implement
+    // const a = getContext();
+    // const randomness = new a.FR(8);
+    // return new PublicKey(a.mul(this.value, randomness));
+    throw new Error("multiplyBy is not implemented by bls-eth-wasm");
+  }
 }

--- a/src/herumi/signature.ts
+++ b/src/herumi/signature.ts
@@ -90,4 +90,13 @@ export class Signature implements ISignature {
   toHex(format?: PointFormat): string {
     return bytesToHex(this.toBytes(format));
   }
+
+  multiplyBy(_bytes: Uint8Array): Signature {
+    // TODO: I found this in the code but its not exported. Need to figure out
+    //       how to implement
+    // const a = getContext();
+    // const randomness = new a.FR(8);
+    // return new Signature(a.mul(this.value, randomness));
+    throw new Error("multiplyBy is not implemented by bls-eth-wasm");
+  }
 }

--- a/src/herumi/web.ts
+++ b/src/herumi/web.ts
@@ -3,5 +3,6 @@ import {bls} from "./index.js";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (function (window: any) {
   window.bls = bls;
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
 })(window);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,6 @@
+export type PublicKeyArg = PublicKey | Uint8Array;
+export type SignatureArg = Signature | Uint8Array;
+
 export interface IBls {
   implementation: Implementation;
   SecretKey: typeof SecretKey;
@@ -5,13 +8,19 @@ export interface IBls {
   Signature: typeof Signature;
 
   sign(secretKey: Uint8Array, message: Uint8Array): Uint8Array;
-  aggregatePublicKeys(publicKeys: Uint8Array[]): Uint8Array;
-  aggregateSignatures(signatures: Uint8Array[]): Uint8Array;
-  verify(publicKey: Uint8Array, message: Uint8Array, signature: Uint8Array): boolean;
-  verifyAggregate(publicKeys: Uint8Array[], message: Uint8Array, signature: Uint8Array): boolean;
-  verifyMultiple(publicKeys: Uint8Array[], messages: Uint8Array[], signature: Uint8Array): boolean;
-  verifyMultipleSignatures(sets: {publicKey: Uint8Array; message: Uint8Array; signature: Uint8Array}[]): boolean;
+  aggregatePublicKeys(publicKeys: PublicKeyArg[]): Uint8Array;
+  aggregateSignatures(signatures: SignatureArg[]): Uint8Array;
+  verify(publicKey: PublicKeyArg, message: Uint8Array, signature: SignatureArg): boolean;
+  verifyAggregate(publicKeys: PublicKeyArg[], message: Uint8Array, signature: SignatureArg): boolean;
+  verifyMultiple(publicKeys: PublicKeyArg[], messages: Uint8Array[], signature: SignatureArg): boolean;
+  verifyMultipleSignatures(sets: {publicKey: PublicKeyArg; message: Uint8Array; signature: SignatureArg}[]): boolean;
   secretKeyToPublicKey(secretKey: Uint8Array): Uint8Array;
+  asyncVerify(message: Uint8Array, publicKey: PublicKeyArg, signature: SignatureArg): Promise<boolean>;
+  asyncVerifyAggregate(message: Uint8Array, publicKeys: PublicKeyArg[], signature: SignatureArg): Promise<boolean>;
+  asyncVerifyMultiple(messages: Uint8Array[], publicKeys: PublicKeyArg[], signature: SignatureArg): Promise<boolean>;
+  asyncVerifyMultipleSignatures(
+    sets: {message: Uint8Array; publicKey: PublicKeyArg; signature: SignatureArg}[]
+  ): Promise<boolean>;
 }
 
 export declare class SecretKey {
@@ -36,6 +45,7 @@ export declare class PublicKey {
   /** @param format Defaults to `PointFormat.compressed` */
   toBytes(format?: PointFormat): Uint8Array;
   toHex(format?: PointFormat): string;
+  multiplyBy(bytes: Uint8Array): PublicKey;
 }
 
 export declare class Signature {
@@ -53,6 +63,7 @@ export declare class Signature {
   /** @param format Defaults to `PointFormat.compressed` */
   toBytes(format?: PointFormat): Uint8Array;
   toHex(format?: PointFormat): string;
+  multiplyBy(bytes: Uint8Array): Signature;
 }
 
 export type Implementation = "herumi" | "blst-native";
@@ -65,4 +76,10 @@ export enum PointFormat {
 export enum CoordType {
   affine = 0,
   jacobian = 1,
+}
+
+export interface SignatureSet {
+  message: Uint8Array;
+  publicKey: PublicKeyArg;
+  signature: SignatureArg;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,17 @@ export enum PointFormat {
   uncompressed = "uncompressed",
 }
 
+/**
+ * NOTE: This MUST match the type used in @chainsafe/blst.  Do not use the one
+ * exported by that library though or it will mess up tree shaking.  Use the one
+ * below instead by MAKE SURE if you change this that it matches the enum values
+ * used by the native bindings in the base library!!!!  Better yet do not modify
+ * this unless you are ABSOLUTELY SURE you know what you are doing...
+ */
+/**
+ * CoordType allows switching between affine and jacobian version of underlying
+ * bls points.
+ */
 export enum CoordType {
   affine = 0,
   jacobian = 1,

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,6 @@ export enum PointFormat {
 }
 
 export enum CoordType {
-  affine,
-  jacobian,
+  affine = 0,
+  jacobian = 1,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,22 @@
+export type Implementation = "herumi" | "blst-native";
 export type PublicKeyArg = PublicKey | Uint8Array;
 export type SignatureArg = Signature | Uint8Array;
+
+export interface SignatureSet {
+  message: Uint8Array;
+  publicKey: PublicKeyArg;
+  signature: SignatureArg;
+}
+
+export enum PointFormat {
+  compressed = "compressed",
+  uncompressed = "uncompressed",
+}
+
+export enum CoordType {
+  affine = 0,
+  jacobian = 1,
+}
 
 export interface IBls {
   implementation: Implementation;
@@ -13,14 +30,12 @@ export interface IBls {
   verify(publicKey: PublicKeyArg, message: Uint8Array, signature: SignatureArg): boolean;
   verifyAggregate(publicKeys: PublicKeyArg[], message: Uint8Array, signature: SignatureArg): boolean;
   verifyMultiple(publicKeys: PublicKeyArg[], messages: Uint8Array[], signature: SignatureArg): boolean;
-  verifyMultipleSignatures(sets: {publicKey: PublicKeyArg; message: Uint8Array; signature: SignatureArg}[]): boolean;
+  verifyMultipleSignatures(sets: SignatureSet[]): boolean;
   secretKeyToPublicKey(secretKey: Uint8Array): Uint8Array;
-  asyncVerify(message: Uint8Array, publicKey: PublicKeyArg, signature: SignatureArg): Promise<boolean>;
-  asyncVerifyAggregate(message: Uint8Array, publicKeys: PublicKeyArg[], signature: SignatureArg): Promise<boolean>;
-  asyncVerifyMultiple(messages: Uint8Array[], publicKeys: PublicKeyArg[], signature: SignatureArg): Promise<boolean>;
-  asyncVerifyMultipleSignatures(
-    sets: {message: Uint8Array; publicKey: PublicKeyArg; signature: SignatureArg}[]
-  ): Promise<boolean>;
+  asyncVerify(publicKey: PublicKeyArg, message: Uint8Array, signature: SignatureArg): Promise<boolean>;
+  asyncVerifyAggregate(publicKeys: PublicKeyArg[], message: Uint8Array, signature: SignatureArg): Promise<boolean>;
+  asyncVerifyMultiple(publicKeys: PublicKeyArg[], messages: Uint8Array[], signature: SignatureArg): Promise<boolean>;
+  asyncVerifyMultipleSignatures(sets: SignatureSet[]): Promise<boolean>;
 }
 
 export declare class SecretKey {
@@ -64,22 +79,4 @@ export declare class Signature {
   toBytes(format?: PointFormat): Uint8Array;
   toHex(format?: PointFormat): string;
   multiplyBy(bytes: Uint8Array): Signature;
-}
-
-export type Implementation = "herumi" | "blst-native";
-
-export enum PointFormat {
-  compressed = "compressed",
-  uncompressed = "uncompressed",
-}
-
-export enum CoordType {
-  affine = 0,
-  jacobian = 1,
-}
-
-export interface SignatureSet {
-  message: Uint8Array;
-  publicKey: PublicKeyArg;
-  signature: SignatureArg;
 }

--- a/test/params.ts
+++ b/test/params.ts
@@ -3,6 +3,6 @@ import {fileURLToPath} from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export const SPEC_TEST_VERSION = "v1.0.0";
+export const SPEC_TEST_VERSION = "v1.3.0";
 export const SPEC_TEST_TO_DOWNLOAD = ["general" as const];
 export const SPEC_TESTS_DIR = path.join(__dirname, "spec-tests");

--- a/test/spec/fast_aggregate_verify.test.ts
+++ b/test/spec/fast_aggregate_verify.test.ts
@@ -1,9 +1,9 @@
 import path from "path";
 import {describeDirectorySpecTest, InputType} from "@lodestar/spec-test-util";
 import {hexToBytes} from "../../src/helpers/index.js";
+import {CoordType} from "../../src/types.js";
 import {SPEC_TESTS_DIR} from "../params.js";
 import {describeForAllImplementations} from "../switch.js";
-import {CoordType} from "@chainsafe/blst";
 
 interface IAggregateSigsVerifyTestCase {
   data: {

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -1,3 +1,4 @@
+const path = require('path');
 const ResolveTypeScriptPlugin = require("resolve-typescript-plugin");
 
 module.exports = {
@@ -7,7 +8,13 @@ module.exports = {
     filename: "dist/bundle.js",
   },
   module: {
-    rules: [{test: /\.(ts)$/, use: {loader: "ts-loader", options: {transpileOnly: true}}}],
+    rules: [
+      {test: /\.(ts)$/, use: {loader: "ts-loader", options: {transpileOnly: true}}},
+      {
+        test: /@chainsafe\/blst/,
+        use: 'null-loader',
+      },
+    ],
   },
   optimization: {
     // Disable minification for better debugging on Karma tests
@@ -16,14 +23,17 @@ module.exports = {
   },
   devtool: "source-map",
   resolve: {
-    plugins: [new ResolveTypeScriptPlugin()],
+    plugins: [
+      new ResolveTypeScriptPlugin(),
+    ],
     alias: {
-      "crypto": "crypto-browserify"
+      "crypto": "crypto-browserify",
+      './blst-native/index.js': path.resolve(__dirname, './src/herumi/index.js')
     },
     fallback: {
       fs: false,
       path: false,
-      stream: false
+      stream: false,
     },
   },
   experiments: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -161,13 +161,14 @@
     "@noble/hashes" "^1.0.0"
     "@scure/bip39" "^1.0.0"
 
-"@chainsafe/blst@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-0.2.4.tgz#ed0737dcf52a8775bd163c9a892424fa365d2c8b"
-  integrity sha512-jjhB4dALUvLdTc2flHE6BEI7KCvXVGevIP8si4OdtERu+Ed+cc6zBsrpLvOySX9pgAMAmAuTnB349AlmRfmR2Q==
+"@chainsafe/blst@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-1.0.0.tgz#0939f5b38389ca8ae00fcc6b6555063113f611a7"
+  integrity sha512-WQDxFvcG+glmusXnWQ3W4g2tvHuTQEK0/cIZz37TskZJqOqAtOogZsK3cD3j+OoxbdCRT6l08QUCOtPMOLe/zA==
   dependencies:
-    node-fetch "^2.6.1"
-    node-gyp "^8.4.0"
+    node-addon-api "^6.1.0"
+    node-gyp "^10.0.1"
+    ts-node "^10.9.2"
 
 "@chainsafe/eslint-plugin-node@^11.2.3":
   version "11.2.3"
@@ -226,7 +227,7 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@gar/promisify@^1.0.1", "@gar/promisify@^1.1.3":
+"@gar/promisify@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
@@ -244,6 +245,18 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
+
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.0.0"
@@ -370,13 +383,16 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@npmcli/fs@^1.0.0":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-1.1.1.tgz#72f719fe935e687c56a4faecf3c03d06ba593257"
-  integrity sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==
+"@npmcli/agent@^2.0.0":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@npmcli/agent/-/agent-2.2.2.tgz#967604918e62f620a648c7975461c9c9e74fc5d5"
+  integrity sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==
   dependencies:
-    "@gar/promisify" "^1.0.1"
-    semver "^7.3.5"
+    agent-base "^7.1.0"
+    http-proxy-agent "^7.0.0"
+    https-proxy-agent "^7.0.1"
+    lru-cache "^10.0.1"
+    socks-proxy-agent "^8.0.3"
 
 "@npmcli/fs@^2.1.0":
   version "2.1.2"
@@ -386,13 +402,12 @@
     "@gar/promisify" "^1.1.3"
     semver "^7.3.5"
 
-"@npmcli/move-file@^1.0.1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.1.2.tgz#1a82c3e372f7cae9253eb66d72543d6b8685c674"
-  integrity sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==
+"@npmcli/fs@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-3.1.0.tgz#233d43a25a91d68c3a863ba0da6a3f00924a173e"
+  integrity sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==
   dependencies:
-    mkdirp "^1.0.4"
-    rimraf "^3.0.2"
+    semver "^7.3.5"
 
 "@npmcli/move-file@^2.0.0":
   version "2.0.1"
@@ -401,6 +416,11 @@
   dependencies:
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
+
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
 "@scure/base@~1.0.0":
   version "1.0.0"
@@ -414,11 +434,6 @@
   dependencies:
     "@noble/hashes" "~1.0.0"
     "@scure/base" "~1.0.0"
-
-"@tootallnate/once@1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
-  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
 "@tootallnate/once@2":
   version "2.0.0"
@@ -767,6 +782,11 @@ abbrev@1, abbrev@^1.0.0:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abbrev@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz#cf59829b8b4f03f89dda2771cb7f3653828c89bf"
+  integrity sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==
+
 accepts@~1.3.4:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -812,14 +832,12 @@ agent-base@6, agent-base@^6.0.2:
   dependencies:
     debug "4"
 
-agentkeepalive@^4.1.3:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.2.1.tgz#a7975cbb9f83b367f06c90cc51ff28fe7d499717"
-  integrity sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==
+agent-base@^7.0.2, agent-base@^7.1.0, agent-base@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.1.tgz#bdbded7dfb096b751a2a087eeeb9664725b2e317"
+  integrity sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==
   dependencies:
-    debug "^4.1.0"
-    depd "^1.1.2"
-    humanize-ms "^1.2.1"
+    debug "^4.3.4"
 
 agentkeepalive@^4.2.1:
   version "4.5.0"
@@ -876,6 +894,11 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
+ansi-regex@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
+  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -897,6 +920,11 @@ ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
+  integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
 any-signal@3.0.1:
   version "3.0.1"
@@ -1210,30 +1238,6 @@ bytes@3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
-cacache@^15.2.0:
-  version "15.3.0"
-  resolved "https://registry.yarnpkg.com/cacache/-/cacache-15.3.0.tgz#dc85380fb2f556fe3dda4c719bfa0ec875a7f1eb"
-  integrity sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==
-  dependencies:
-    "@npmcli/fs" "^1.0.0"
-    "@npmcli/move-file" "^1.0.1"
-    chownr "^2.0.0"
-    fs-minipass "^2.0.0"
-    glob "^7.1.4"
-    infer-owner "^1.0.4"
-    lru-cache "^6.0.0"
-    minipass "^3.1.1"
-    minipass-collect "^1.0.2"
-    minipass-flush "^1.0.5"
-    minipass-pipeline "^1.2.2"
-    mkdirp "^1.0.3"
-    p-map "^4.0.0"
-    promise-inflight "^1.0.1"
-    rimraf "^3.0.2"
-    ssri "^8.0.1"
-    tar "^6.0.2"
-    unique-filename "^1.1.1"
-
 cacache@^16.1.0:
   version "16.1.3"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-16.1.3.tgz#a02b9f34ecfaf9a78c9f4bc16fceb94d5d67a38e"
@@ -1257,6 +1261,24 @@ cacache@^16.1.0:
     ssri "^9.0.0"
     tar "^6.1.11"
     unique-filename "^2.0.0"
+
+cacache@^18.0.0:
+  version "18.0.2"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-18.0.2.tgz#fd527ea0f03a603be5c0da5805635f8eef00c60c"
+  integrity sha512-r3NU8h/P+4lVUHfeRw1dtgQYar3DZMm4/cm2bZgOvrFC/su7budSOeqh52VJIC4U4iG1WWwV6vRW0znqBvxNuw==
+  dependencies:
+    "@npmcli/fs" "^3.1.0"
+    fs-minipass "^3.0.0"
+    glob "^10.2.2"
+    lru-cache "^10.0.1"
+    minipass "^7.0.3"
+    minipass-collect "^2.0.1"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.4"
+    p-map "^4.0.0"
+    ssri "^10.0.0"
+    tar "^6.1.11"
+    unique-filename "^3.0.0"
 
 caching-transform@^4.0.0:
   version "4.0.0"
@@ -1719,11 +1741,6 @@ depd@2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-depd@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
-  integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
-
 des.js@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.1.0.tgz#1d37f5766f3bbff4ee9638e871a8768c173b81da"
@@ -1798,6 +1815,11 @@ dom-serialize@^2.2.1:
     extend "^3.0.0"
     void-elements "^2.0.0"
 
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -1826,12 +1848,17 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-encoding@^0.1.12, encoding@^0.1.13:
+encoding@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
   integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
@@ -2178,6 +2205,11 @@ execa@^5.0.0:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
+exponential-backoff@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
+  integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
+
 extend@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
@@ -2326,6 +2358,14 @@ foreground-child@^2.0.0:
     cross-spawn "^7.0.0"
     signal-exit "^3.0.2"
 
+foreground-child@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.1.1.tgz#1d173e776d75d2772fed08efe4a0de1ea1b12d0d"
+  integrity sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==
+  dependencies:
+    cross-spawn "^7.0.0"
+    signal-exit "^4.0.1"
+
 form-data@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
@@ -2355,6 +2395,13 @@ fs-minipass@^2.0.0, fs-minipass@^2.1.0:
   integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
   dependencies:
     minipass "^3.0.0"
+
+fs-minipass@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-3.0.3.tgz#79a85981c4dc120065e96f62086bf6f9dc26cc54"
+  integrity sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==
+  dependencies:
+    minipass "^7.0.3"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2462,6 +2509,17 @@ glob@7.2.0, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^10.2.2, glob@^10.3.10:
+  version "10.3.12"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.3.12.tgz#3a65c363c2e9998d220338e88a5f6ac97302960b"
+  integrity sha512-TCNv8vJ+xz4QiqTpfOJA7HvYv+tNIRHKfUWw/q+v2jdgN4ebz+KY9tGx5J4rHP0o84mNP+ApH66HRX8us3Khqg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^2.3.6"
+    minimatch "^9.0.1"
+    minipass "^7.0.4"
+    path-scurry "^1.10.2"
 
 glob@^8.0.1:
   version "8.1.0"
@@ -2598,6 +2656,11 @@ http-cache-semantics@^4.1.0:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
 
+http-cache-semantics@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
+  integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
+
 http-errors@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
@@ -2609,15 +2672,6 @@ http-errors@2.0.0:
     statuses "2.0.1"
     toidentifier "1.0.1"
 
-http-proxy-agent@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
-  integrity sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
-  dependencies:
-    "@tootallnate/once" "1"
-    agent-base "6"
-    debug "4"
-
 http-proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
@@ -2626,6 +2680,14 @@ http-proxy-agent@^5.0.0:
     "@tootallnate/once" "2"
     agent-base "6"
     debug "4"
+
+http-proxy-agent@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
 
 http-proxy@^1.18.1:
   version "1.18.1"
@@ -2642,6 +2704,14 @@ https-proxy-agent@^5.0.0:
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
   dependencies:
     agent-base "6"
+    debug "4"
+
+https-proxy-agent@^7.0.1:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz#8e97b841a029ad8ddc8731f26595bad868cb4168"
+  integrity sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==
+  dependencies:
+    agent-base "^7.0.2"
     debug "4"
 
 human-signals@^2.1.0:
@@ -2741,6 +2811,14 @@ interpret@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
+
+ip-address@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-9.0.5.tgz#117a960819b08780c3bd1f14ef3c1cc1d3f3ea5a"
+  integrity sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==
+  dependencies:
+    jsbn "1.1.0"
+    sprintf-js "^1.1.3"
 
 ip@^1.1.5:
   version "1.1.8"
@@ -2881,6 +2959,11 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
+isexe@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-3.1.1.tgz#4a407e2bd78ddfb14bea0c27c6f7072dde775f0d"
+  integrity sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==
+
 isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
@@ -2950,6 +3033,15 @@ istanbul-reports@^3.0.0:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+jackspeak@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-2.3.6.tgz#647ecc472238aee4b06ac0e461acc21a8c505ca8"
+  integrity sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
+
 jest-worker@^27.4.5:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.5.1.tgz#8d146f0900e8973b106b6f73cc1e9a8cb86f8db0"
@@ -2978,6 +3070,11 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+jsbn@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
+  integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -3195,12 +3292,10 @@ loupe@^2.3.6:
   dependencies:
     get-func-name "^2.0.1"
 
-lru-cache@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
-  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
-  dependencies:
-    yallist "^4.0.0"
+lru-cache@^10.0.1, lru-cache@^10.2.0, "lru-cache@^9.1.1 || ^10.0.0":
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.0.tgz#0bd445ca57363465900f4d1f9bd8db343a4d95c3"
+  integrity sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==
 
 lru-cache@^7.4.0:
   version "7.7.3"
@@ -3211,11 +3306,6 @@ lru-cache@^7.7.1:
   version "7.18.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
-
-"lru-cache@^9.1.1 || ^10.0.0":
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.0.tgz#0bd445ca57363465900f4d1f9bd8db343a4d95c3"
-  integrity sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==
 
 make-dir@^3.0.0:
   version "3.0.2"
@@ -3258,27 +3348,22 @@ make-fetch-happen@^10.0.3:
     socks-proxy-agent "^7.0.0"
     ssri "^9.0.0"
 
-make-fetch-happen@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz#53085a09e7971433e6765f7971bf63f4e05cb968"
-  integrity sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==
+make-fetch-happen@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-13.0.0.tgz#705d6f6cbd7faecb8eac2432f551e49475bfedf0"
+  integrity sha512-7ThobcL8brtGo9CavByQrQi+23aIfgYU++wg4B87AIS8Rb2ZBt/MEaDqzA00Xwv/jUjAjYkLHjVolYuTLKda2A==
   dependencies:
-    agentkeepalive "^4.1.3"
-    cacache "^15.2.0"
-    http-cache-semantics "^4.1.0"
-    http-proxy-agent "^4.0.1"
-    https-proxy-agent "^5.0.0"
+    "@npmcli/agent" "^2.0.0"
+    cacache "^18.0.0"
+    http-cache-semantics "^4.1.1"
     is-lambda "^1.0.1"
-    lru-cache "^6.0.0"
-    minipass "^3.1.3"
-    minipass-collect "^1.0.2"
-    minipass-fetch "^1.3.2"
+    minipass "^7.0.2"
+    minipass-fetch "^3.0.0"
     minipass-flush "^1.0.5"
     minipass-pipeline "^1.2.4"
-    negotiator "^0.6.2"
+    negotiator "^0.6.3"
     promise-retry "^2.0.1"
-    socks-proxy-agent "^6.0.0"
-    ssri "^8.0.0"
+    ssri "^10.0.0"
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -3407,6 +3492,13 @@ minimatch@^8.0.2:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimatch@^9.0.1:
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.4.tgz#8e49c731d1749cbec05050ee5145147b32496a51"
+  integrity sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
@@ -3419,16 +3511,12 @@ minipass-collect@^1.0.2:
   dependencies:
     minipass "^3.0.0"
 
-minipass-fetch@^1.3.2:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-1.4.1.tgz#d75e0091daac1b0ffd7e9d41629faff7d0c1f1b6"
-  integrity sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==
+minipass-collect@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/minipass-collect/-/minipass-collect-2.0.1.tgz#1621bc77e12258a12c60d34e2276ec5c20680863"
+  integrity sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==
   dependencies:
-    minipass "^3.1.0"
-    minipass-sized "^1.0.3"
-    minizlib "^2.0.0"
-  optionalDependencies:
-    encoding "^0.1.12"
+    minipass "^7.0.3"
 
 minipass-fetch@^2.0.3:
   version "2.1.2"
@@ -3441,6 +3529,17 @@ minipass-fetch@^2.0.3:
   optionalDependencies:
     encoding "^0.1.13"
 
+minipass-fetch@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-3.0.4.tgz#4d4d9b9f34053af6c6e597a64be8e66e42bf45b7"
+  integrity sha512-jHAqnA728uUpIaFm7NWsCnqKT6UqZz7GcI/bDpPATuwYyKwJwW0remxSCxUlKiEty+eopHGa3oc8WxgQ1FFJqg==
+  dependencies:
+    minipass "^7.0.3"
+    minipass-sized "^1.0.3"
+    minizlib "^2.1.2"
+  optionalDependencies:
+    encoding "^0.1.13"
+
 minipass-flush@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/minipass-flush/-/minipass-flush-1.0.5.tgz#82e7135d7e89a50ffe64610a787953c4c4cbb373"
@@ -3448,7 +3547,7 @@ minipass-flush@^1.0.5:
   dependencies:
     minipass "^3.0.0"
 
-minipass-pipeline@^1.2.2, minipass-pipeline@^1.2.4:
+minipass-pipeline@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz#68472f79711c084657c067c5c6ad93cddea8214c"
   integrity sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==
@@ -3462,7 +3561,7 @@ minipass-sized@^1.0.3:
   dependencies:
     minipass "^3.0.0"
 
-minipass@^3.0.0, minipass@^3.1.0, minipass@^3.1.1, minipass@^3.1.3:
+minipass@^3.0.0, minipass@^3.1.1:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.6.tgz#3b8150aa688a711a1521af5e8779c1d3bb4f45ee"
   integrity sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==
@@ -3486,12 +3585,12 @@ minipass@^5.0.0:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
   integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0":
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.2, minipass@^7.0.3, minipass@^7.0.4:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.0.4.tgz#dbce03740f50a4786ba994c1fb908844d27b038c"
   integrity sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==
 
-minizlib@^2.0.0, minizlib@^2.1.1, minizlib@^2.1.2:
+minizlib@^2.1.1, minizlib@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
   integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
@@ -3609,7 +3708,7 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-negotiator@^0.6.2, negotiator@^0.6.3:
+negotiator@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
@@ -3619,12 +3718,10 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-node-fetch@^2.6.1:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
-  dependencies:
-    whatwg-url "^5.0.0"
+node-addon-api@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-6.1.0.tgz#ac8470034e58e67d0c6f1204a18ae6995d9c0d76"
+  integrity sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==
 
 node-fetch@^2.6.5:
   version "2.7.0"
@@ -3649,21 +3746,21 @@ node-gyp@9.3.1:
     tar "^6.1.2"
     which "^2.0.2"
 
-node-gyp@^8.4.0:
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-8.4.1.tgz#3d49308fc31f768180957d6b5746845fbd429937"
-  integrity sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==
+node-gyp@^10.0.1:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-10.1.0.tgz#75e6f223f2acb4026866c26a2ead6aab75a8ca7e"
+  integrity sha512-B4J5M1cABxPc5PwfjhbV5hoy2DP9p8lFXASnEN6hugXOa61416tnTZ29x9sSwAd0o99XNIcpvDDy1swAExsVKA==
   dependencies:
     env-paths "^2.2.0"
-    glob "^7.1.4"
+    exponential-backoff "^3.1.1"
+    glob "^10.3.10"
     graceful-fs "^4.2.6"
-    make-fetch-happen "^9.1.0"
-    nopt "^5.0.0"
-    npmlog "^6.0.0"
-    rimraf "^3.0.2"
+    make-fetch-happen "^13.0.0"
+    nopt "^7.0.0"
+    proc-log "^3.0.0"
     semver "^7.3.5"
     tar "^6.1.2"
-    which "^2.0.2"
+    which "^4.0.0"
 
 node-preload@^0.2.0:
   version "0.2.1"
@@ -3690,6 +3787,13 @@ nopt@^6.0.0:
   integrity sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==
   dependencies:
     abbrev "^1.0.0"
+
+nopt@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-7.2.0.tgz#067378c68116f602f552876194fd11f1292503d7"
+  integrity sha512-CVDtwCdhYIvnAzFoJ6NJ6dX3oga9/HyciQDnG1vQDjSLMeKLJ4A93ZqYKDrgYSr1FBY5/hMYC+2VCi24pgpkGA==
+  dependencies:
+    abbrev "^2.0.0"
 
 normalize-package-data@^2.3.2:
   version "2.5.0"
@@ -3983,6 +4087,14 @@ path-parse@^1.0.6, path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+path-scurry@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.10.2.tgz#8f6357eb1239d5fa1da8b9f70e9c080675458ba7"
+  integrity sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
 path-scurry@^1.6.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.10.1.tgz#9ba6bf5aa8500fe9fd67df4f0d9483b2b0bfc698"
@@ -4074,6 +4186,11 @@ prettier@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
   integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
+
+proc-log@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/proc-log/-/proc-log-3.0.0.tgz#fb05ef83ccd64fd7b20bbe9c8c1070fc08338dd8"
+  integrity sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==
 
 process-on-spawn@^1.0.0:
   version "1.0.0"
@@ -4469,6 +4586,11 @@ signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -4519,15 +4641,6 @@ socket.io@^4.4.1:
     socket.io-adapter "~2.3.3"
     socket.io-parser "~4.0.4"
 
-socks-proxy-agent@^6.0.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-6.2.0.tgz#f6b5229cc0cbd6f2f202d9695f09d871e951c85e"
-  integrity sha512-wWqJhjb32Q6GsrUqzuFkukxb/zzide5quXYcMVpIjxalDBBYy2nqKCFQ/9+Ie4dvOYSQdOk3hUlZSdzZOd3zMQ==
-  dependencies:
-    agent-base "^6.0.2"
-    debug "^4.3.3"
-    socks "^2.6.2"
-
 socks-proxy-agent@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz#dc069ecf34436621acb41e3efa66ca1b5fed15b6"
@@ -4537,12 +4650,29 @@ socks-proxy-agent@^7.0.0:
     debug "^4.3.3"
     socks "^2.6.2"
 
+socks-proxy-agent@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz#6b2da3d77364fde6292e810b496cb70440b9b89d"
+  integrity sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==
+  dependencies:
+    agent-base "^7.1.1"
+    debug "^4.3.4"
+    socks "^2.7.1"
+
 socks@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.2.tgz#ec042d7960073d40d94268ff3bb727dc685f111a"
   integrity sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==
   dependencies:
     ip "^1.1.5"
+    smart-buffer "^4.2.0"
+
+socks@^2.7.1:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.8.3.tgz#1ebd0f09c52ba95a09750afe3f3f9f724a800cb5"
+  integrity sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==
+  dependencies:
+    ip-address "^9.0.5"
     smart-buffer "^4.2.0"
 
 source-map-support@~0.5.20:
@@ -4601,17 +4731,22 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
+sprintf-js@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a"
+  integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-ssri@^8.0.0, ssri@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.1.tgz#638e4e439e2ffbd2cd289776d5ca457c4f51a2af"
-  integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
+ssri@^10.0.0:
+  version "10.0.5"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-10.0.5.tgz#e49efcd6e36385196cb515d3a2ad6c3f0265ef8c"
+  integrity sha512-bSf16tAFkGeRlUNDjXu8FzaMQt6g2HZJrun7mtMbIPOddxt3GLMSz5VWUWcqTJUPfLEaDIepGxv+bYQW49596A==
   dependencies:
-    minipass "^3.1.1"
+    minipass "^7.0.3"
 
 ssri@^9.0.0:
   version "9.0.1"
@@ -4639,7 +4774,7 @@ streamroller@^3.0.8:
     debug "^4.3.4"
     fs-extra "^10.1.0"
 
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4656,6 +4791,15 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
 
 string.prototype.trimleft@^2.1.1:
   version "2.1.1"
@@ -4680,6 +4824,13 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-ansi@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
@@ -4687,12 +4838,12 @@ strip-ansi@^6.0.0:
   dependencies:
     ansi-regex "^5.0.0"
 
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+strip-ansi@^7.0.1:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.0.tgz#d5b6568ca689d8561370b0707685d22434faff45"
+  integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==
   dependencies:
-    ansi-regex "^5.0.1"
+    ansi-regex "^6.0.1"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -4756,18 +4907,6 @@ tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tar@^6.0.2, tar@^6.1.2:
-  version "6.1.11"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
-  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
-  dependencies:
-    chownr "^2.0.0"
-    fs-minipass "^2.0.0"
-    minipass "^3.0.0"
-    minizlib "^2.1.1"
-    mkdirp "^1.0.3"
-    yallist "^4.0.0"
-
 tar@^6.1.11, tar@^6.1.13:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.0.tgz#b14ce49a79cb1cd23bc9b016302dea5474493f73"
@@ -4776,6 +4915,18 @@ tar@^6.1.11, tar@^6.1.13:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
     minipass "^5.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
+tar@^6.1.2:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
@@ -4880,6 +5031,25 @@ ts-node@^10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
+ts-node@^10.9.2:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 tslib@2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
@@ -4949,13 +5119,6 @@ undici-types@~5.26.4:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
-unique-filename@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230"
-  integrity sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==
-  dependencies:
-    unique-slug "^2.0.0"
-
 unique-filename@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-2.0.1.tgz#e785f8675a9a7589e0ac77e0b5c34d2eaeac6da2"
@@ -4963,17 +5126,24 @@ unique-filename@^2.0.0:
   dependencies:
     unique-slug "^3.0.0"
 
-unique-slug@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.2.tgz#baabce91083fc64e945b0f3ad613e264f7cd4e6c"
-  integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
+unique-filename@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-3.0.0.tgz#48ba7a5a16849f5080d26c760c86cf5cf05770ea"
+  integrity sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==
   dependencies:
-    imurmurhash "^0.1.4"
+    unique-slug "^4.0.0"
 
 unique-slug@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-3.0.0.tgz#6d347cf57c8a7a7a6044aabd0e2d74e4d76dc7c9"
   integrity sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==
+  dependencies:
+    imurmurhash "^0.1.4"
+
+unique-slug@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-4.0.0.tgz#6bae6bb16be91351badd24cdce741f892a6532e3"
+  integrity sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==
   dependencies:
     imurmurhash "^0.1.4"
 
@@ -5161,6 +5331,13 @@ which@^1.2.1:
   dependencies:
     isexe "^2.0.0"
 
+which@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-4.0.0.tgz#cd60b5e74503a3fbcfbf6cd6b4138a8bae644c1a"
+  integrity sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==
+  dependencies:
+    isexe "^3.1.1"
+
 wide-align@^1.1.2, wide-align@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
@@ -5188,6 +5365,15 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
@@ -5197,14 +5383,14 @@ wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
   dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
 
 wrappy@1:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1067,6 +1067,11 @@ base64id@2.0.0, base64id@~2.0.0:
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-2.0.0.tgz#2770ac6bc47d312af97a8bf9a634342e0cd25cb6"
   integrity sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==
 
+big.js@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
+  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
 bigint-buffer@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/bigint-buffer/-/bigint-buffer-1.1.5.tgz#d038f31c8e4534c1f8d0015209bf34b4fa6dd442"
@@ -1852,6 +1857,11 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+emojis-list@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
+  integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -3108,6 +3118,11 @@ json5@^2.1.0:
   dependencies:
     minimist "^1.2.0"
 
+json5@^2.1.2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
@@ -3216,6 +3231,15 @@ loader-runner@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.3.0.tgz#c1b4a163b99f614830353b16755e7149ac2314e1"
   integrity sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==
+
+loader-utils@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -3836,6 +3860,14 @@ npmlog@^6.0.0:
     console-control-strings "^1.1.0"
     gauge "^4.0.3"
     set-blocking "^2.0.0"
+
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 nyc@^15.0.0:
   version "15.0.0"
@@ -4481,19 +4513,19 @@ safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-schema-utils@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz#bc74c4b6b6995c1d88f76a8b77bea7219e0c8281"
-  integrity sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==
+schema-utils@^3.0.0, schema-utils@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.3.0.tgz#f50a88877c3c01652a15b622ae9e9795df7a60fe"
+  integrity sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==
   dependencies:
     "@types/json-schema" "^7.0.8"
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
-schema-utils@^3.2.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.3.0.tgz#f50a88877c3c01652a15b622ae9e9795df7a60fe"
-  integrity sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==
+schema-utils@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz#bc74c4b6b6995c1d88f76a8b77bea7219e0c8281"
+  integrity sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==
   dependencies:
     "@types/json-schema" "^7.0.8"
     ajv "^6.12.5"


### PR DESCRIPTION
**Description**

- Update major package version
- Update `@chainsafe/blst` version to `1.0.0`
- Update spec tests to version `1.3.0`
- Widen types from just `Uint8Array` to either `PublicKeyArg` or `SignatureArg`
- Match `CoordType` to the one exported and used by `@chainsafe/blst` so its not a required dep for tree shaking
- Implement napi version of blst in `blst-native` folder
- Pass implementation into `functionalInterfaceFactory` to allow for async version of functions
- Return sync version of function for herumi and use napi version for blst-native
- Implement `multiplyBy` for `blst-native` _**note:**_ throws for hermui because not implemented by base library
- Lint code
- Add `null-loader` to exclude `@chainsafe/blst` from the webpack bundle to fix web test