### PR TITLE
fix: async implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ yarn add @chainsafe/bls @chainsafe/blst
 
 By default, native bindings will be used if in NodeJS and they are installed. A WASM implementation ("herumi") is used as a fallback in case any error occurs.
 
+The `blst-native` implementation offers a multi-threaded approach to verification and utilizes the libuv worker pool to verification.  It is a more performant options synchronously and FAR better when utilized asynchronously.  All verification functions provide sync and async versions.  Both the `blst-native` and `herumi` implementations offer verification functions with `async` prefixes as free functions and also on their respective classes. This was done to preserve the isomorphic architecture of this library. In reality however, only the `blst-native` bindings have the ability to implement a promise based approach. In the `herumi` version the async version just proxies to the sync version under the hood.
+
 ```ts
 import bls from "@chainsafe/bls";
 
@@ -106,7 +108,7 @@ Results are in `ops/sec (x times slower)`, where `x times slower` = times slower
 
 \* `blst` and `herumi` performed 100 runs each, `noble` 10 runs.
 
-Results from CI run https://github.com/ChainSafe/bls/runs/1513710175?check_suite_focus=true#step:12:13
+Results from CI run <https://github.com/ChainSafe/bls/runs/1513710175?check_suite_focus=true#step:12:13>
 
 ## Spec versioning
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/bls",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Implementation of bls signature verification for ethereum 2.0",
   "engines": {
     "node": ">=18"

--- a/src/blst-native/publicKey.ts
+++ b/src/blst-native/publicKey.ts
@@ -1,7 +1,7 @@
 import blst from "@chainsafe/blst";
 import {EmptyAggregateError} from "../errors.js";
 import {bytesToHex, hexToBytes} from "../helpers/index.js";
-import {CoordType, PointFormat, PublicKey as IPublicKey} from "../types.js";
+import {CoordType, PointFormat, PublicKey as IPublicKey, PublicKeyArg} from "../types.js";
 
 export class PublicKey implements IPublicKey {
   private constructor(private readonly value: blst.PublicKey) {}
@@ -18,13 +18,17 @@ export class PublicKey implements IPublicKey {
     return this.fromBytes(hexToBytes(hex));
   }
 
-  static aggregate(publicKeys: PublicKey[]): PublicKey {
+  static aggregate(publicKeys: PublicKeyArg[]): PublicKey {
     if (publicKeys.length === 0) {
       throw new EmptyAggregateError();
     }
 
-    const pk = blst.aggregatePublicKeys(publicKeys.map(({value}) => value));
+    const pk = blst.aggregatePublicKeys(publicKeys.map(PublicKey.convertToBlstPublicKeyArg));
     return new PublicKey(pk);
+  }
+
+  static convertToBlstPublicKeyArg(publicKey: PublicKeyArg): blst.PublicKeyArg {
+    return publicKey instanceof PublicKey ? publicKey.value : (publicKey as Uint8Array);
   }
 
   /**

--- a/src/blst-native/publicKey.ts
+++ b/src/blst-native/publicKey.ts
@@ -28,7 +28,8 @@ export class PublicKey implements IPublicKey {
   }
 
   static convertToBlstPublicKeyArg(publicKey: PublicKeyArg): blst.PublicKeyArg {
-    return publicKey instanceof PublicKey ? publicKey.value : (publicKey as Uint8Array);
+    // need to cast to blst-native key instead of IPublicKey
+    return publicKey instanceof Uint8Array ? publicKey : (publicKey as PublicKey).value;
   }
 
   /**

--- a/src/blst-native/signature.ts
+++ b/src/blst-native/signature.ts
@@ -49,7 +49,8 @@ export class Signature implements ISignature {
   }
 
   static convertToBlstSignatureArg(signature: SignatureArg): blst.SignatureArg {
-    return signature instanceof Signature ? signature.value : (signature as Uint8Array);
+    // Need to cast to blst-native Signature instead of ISignature
+    return signature instanceof Uint8Array ? signature : (signature as Signature).value;
   }
 
   /**

--- a/src/blst-native/signature.ts
+++ b/src/blst-native/signature.ts
@@ -131,10 +131,11 @@ export class Signature implements ISignature {
     // This has the effect of always declaring that this sig/publicKey combination is valid.
     // for Eth2.0 specs tests
     if (publicKeys.length === 1) {
+      const publicKey = publicKeys[0];
       // eslint-disable-next-line prettier/prettier
-      const pk: PublicKey = publicKeys[0] instanceof Uint8Array 
-        ? PublicKey.fromBytes(publicKeys[0]) 
-        : (publicKeys[0] as PublicKey); // need to cast to blst-native key instead of IPublicKey
+      const pk: PublicKey = publicKey instanceof Uint8Array 
+        ? PublicKey.fromBytes(publicKey) 
+        : (publicKey as PublicKey); // need to cast to blst-native key instead of IPublicKey
       // @ts-expect-error Need to hack type to get access to the private `value`
       if (this.value.isInfinity() && pk.value.isInfinity()) {
         return runAsync ? Promise.resolve(true) : true;

--- a/src/functional.ts
+++ b/src/functional.ts
@@ -9,7 +9,7 @@ import {NotInitializedError} from "./errors.js";
  * downstream issues in the WASM code. It is not necessary to validateBytes for blst-native
  * code. The check for blst-native is implemented in the native layer.  All other byte checks
  * for the herumi code paths are found in the herumi classes for performance reasons as they
- * are byte-wise, only are required for the WASM and will unnecessarily slow down the 
+ * are byte-wise, only are required for the WASM and will unnecessarily slow down the
  * blst-native side.
  */
 // if (implementation === "herumi" && signature instanceof Uint8Array) {

--- a/src/functional.ts
+++ b/src/functional.ts
@@ -2,6 +2,20 @@ import {IBls, PublicKeyArg, SignatureArg, SignatureSet} from "./types.js";
 import {validateBytes} from "./helpers/index.js";
 import {NotInitializedError} from "./errors.js";
 
+/**
+ * NOTE:
+ *
+ * This conditional block below is present in most functions and is Herumi specific to prevent
+ * downstream issues in the WASM code. It is not necessary to validateBytes for blst-native
+ * code. The check for blst-native is implemented in the native layer.  All other byte checks
+ * for the herumi code paths are found in the herumi classes for performance reasons as they
+ * are byte-wise, only are required for the WASM and will unnecessarily slow down the 
+ * blst-native side.
+ */
+// if (implementation === "herumi" && signature instanceof Uint8Array) {
+//   validateBytes(signature, "signature");
+// }
+
 // Returned type is enforced at each implementation's index
 // eslint-disable-next-line max-len
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type,@typescript-eslint/explicit-module-boundary-types

--- a/src/functional.ts
+++ b/src/functional.ts
@@ -132,7 +132,7 @@ export function functionalInterfaceFactory({
     try {
       // must be in try/catch in case sig is invalid
       const sig = signature instanceof Signature ? signature : Signature.fromBytes(signature);
-      return sig.asyncVerify(publicKey, message);
+      return await sig.asyncVerify(publicKey, message);
     } catch (e) {
       if (e instanceof NotInitializedError) throw e;
       return false;
@@ -150,7 +150,7 @@ export function functionalInterfaceFactory({
     if (implementation === "herumi") return verifyAggregate(publicKeys, message, signature);
     try {
       const sig = signature instanceof Signature ? signature : Signature.fromBytes(signature);
-      return sig.asyncVerifyAggregate(publicKeys, message);
+      return await sig.asyncVerifyAggregate(publicKeys, message);
     } catch (e) {
       if (e instanceof NotInitializedError) throw e;
       return false;
@@ -168,7 +168,7 @@ export function functionalInterfaceFactory({
     if (implementation === "herumi") return verifyMultiple(publicKeys, messages, signature);
     try {
       const sig = signature instanceof Signature ? signature : Signature.fromBytes(signature);
-      return sig.asyncVerifyMultiple(publicKeys, messages);
+      return await sig.asyncVerifyMultiple(publicKeys, messages);
     } catch (e) {
       if (e instanceof NotInitializedError) throw e;
       return false;
@@ -188,7 +188,7 @@ export function functionalInterfaceFactory({
   async function asyncVerifyMultipleSignatures(sets: SignatureSet[]): Promise<boolean> {
     try {
       if (implementation === "herumi") return Signature.verifyMultipleSignatures(sets);
-      return Signature.asyncVerifyMultipleSignatures(sets);
+      return await Signature.asyncVerifyMultipleSignatures(sets);
     } catch (e) {
       if (e instanceof NotInitializedError) throw e;
       return false;

--- a/src/herumi/publicKey.ts
+++ b/src/herumi/publicKey.ts
@@ -1,7 +1,7 @@
-import type {PublicKeyType} from "bls-eth-wasm";
+import {PublicKeyType} from "bls-eth-wasm";
 import {getContext} from "./context.js";
-import {bytesToHex, hexToBytes, isZeroUint8Array} from "../helpers/index.js";
-import {PointFormat, PublicKey as IPublicKey} from "../types.js";
+import {bytesToHex, hexToBytes, isZeroUint8Array, validateBytes} from "../helpers/index.js";
+import {PointFormat, PublicKey as IPublicKey, PublicKeyArg} from "../types.js";
 import {EmptyAggregateError, InvalidLengthError, ZeroPublicKeyError} from "../errors.js";
 import {PUBLIC_KEY_LENGTH_COMPRESSED, PUBLIC_KEY_LENGTH_UNCOMPRESSED} from "../constants.js";
 
@@ -35,16 +35,28 @@ export class PublicKey implements IPublicKey {
     return this.fromBytes(hexToBytes(hex));
   }
 
-  static aggregate(publicKeys: PublicKey[]): PublicKey {
+  static aggregate(publicKeys: PublicKeyArg[]): PublicKey {
     if (publicKeys.length === 0) {
       throw new EmptyAggregateError();
     }
-
-    const agg = new PublicKey(publicKeys[0].value.clone());
-    for (const pk of publicKeys.slice(1)) {
-      agg.value.add(pk.value);
+    const context = getContext();
+    const agg = new context.PublicKey();
+    for (const publicKey of publicKeys) {
+      agg.add(PublicKey.convertToPublicKeyType(publicKey));
     }
-    return agg;
+    return new PublicKey(agg);
+  }
+
+  static convertToPublicKeyType(publicKey: PublicKeyArg): PublicKeyType {
+    let pk: PublicKey;
+    if (publicKey instanceof Uint8Array) {
+      validateBytes(publicKey, "publicKey");
+      pk = PublicKey.fromBytes(publicKey);
+    } else {
+      // need to cast to herumi key instead of IPublicKey
+      pk = publicKey as PublicKey;
+    }
+    return pk.value;
   }
 
   toBytes(format?: PointFormat): Uint8Array {

--- a/src/herumi/signature.ts
+++ b/src/herumi/signature.ts
@@ -1,8 +1,8 @@
 import type {SignatureType} from "bls-eth-wasm";
 import {getContext} from "./context.js";
 import {PublicKey} from "./publicKey.js";
-import {bytesToHex, concatUint8Arrays, hexToBytes, isZeroUint8Array} from "../helpers/index.js";
-import {SignatureSet, PointFormat, Signature as ISignature, CoordType} from "../types.js";
+import {bytesToHex, concatUint8Arrays, hexToBytes, isZeroUint8Array, validateBytes} from "../helpers/index.js";
+import {SignatureSet, PointFormat, Signature as ISignature, CoordType, PublicKeyArg, SignatureArg} from "../types.js";
 import {EmptyAggregateError, InvalidLengthError, InvalidOrderError} from "../errors.js";
 import {SIGNATURE_LENGTH_COMPRESSED, SIGNATURE_LENGTH_UNCOMPRESSED} from "../constants.js";
 
@@ -41,22 +41,24 @@ export class Signature implements ISignature {
     return this.fromBytes(hexToBytes(hex));
   }
 
-  static aggregate(signatures: Signature[]): Signature {
+  static aggregate(signatures: SignatureArg[]): Signature {
     if (signatures.length === 0) {
       throw new EmptyAggregateError();
     }
 
     const context = getContext();
-    const signature = new context.Signature();
-    signature.aggregate(signatures.map((sig) => sig.value));
-    return new Signature(signature);
+    const agg = new context.Signature();
+    agg.aggregate(signatures.map(Signature.convertToSignatureType));
+    return new Signature(agg);
   }
 
   static verifyMultipleSignatures(sets: SignatureSet[]): boolean {
+    if (!sets) throw Error("sets is null or undefined");
+
     const context = getContext();
     return context.multiVerify(
-      sets.map((s) => s.publicKey.value),
-      sets.map((s) => s.signature.value),
+      sets.map((s) => PublicKey.convertToPublicKeyType(s.publicKey)),
+      sets.map((s) => Signature.convertToSignatureType(s.signature)),
       sets.map((s) => s.message)
     );
   }
@@ -70,20 +72,40 @@ export class Signature implements ISignature {
     return Signature.verifyMultipleSignatures(sets);
   }
 
-  verify(publicKey: PublicKey, message: Uint8Array): boolean {
-    return publicKey.value.verify(this.value, message);
+  static convertToSignatureType(signature: SignatureArg): SignatureType {
+    let sig: Signature;
+    if (signature instanceof Uint8Array) {
+      validateBytes(signature, "signature");
+      sig = Signature.fromBytes(signature);
+    } else {
+      // need to cast to herumi key instead of ISignature
+      sig = signature as Signature;
+    }
+    return sig.value;
   }
 
-  verifyAggregate(publicKeys: PublicKey[], message: Uint8Array): boolean {
-    return this.value.fastAggregateVerify(
-      publicKeys.map((key) => key.value),
-      message
-    );
+  verify(publicKey: PublicKeyArg, message: Uint8Array): boolean {
+    validateBytes(message, "message");
+    return PublicKey.convertToPublicKeyType(publicKey).verify(this.value, message);
   }
 
-  verifyMultiple(publicKeys: PublicKey[], messages: Uint8Array[]): boolean {
+  verifyAggregate(publicKeys: PublicKeyArg[], message: Uint8Array): boolean {
+    validateBytes(message, "message");
+    return this.value.fastAggregateVerify(publicKeys.map(PublicKey.convertToPublicKeyType), message);
+  }
+
+  verifyMultiple(publicKeys: PublicKeyArg[], messages: Uint8Array[]): boolean {
+    // TODO: (@matthewkeil) this was in the verifyMultiple free function but was moved here for herumi. blst-native
+    //       does this check but throws error instead of returning false.  Need to double check spec on which is
+    //       correct handling
+    if (publicKeys.length === 0 || publicKeys.length != messages.length) {
+      return false;
+    }
+
+    validateBytes(messages, "message");
+
     return this.value.aggregateVerifyNoCheck(
-      publicKeys.map((key) => key.value),
+      publicKeys.map(PublicKey.convertToPublicKeyType),
       concatUint8Arrays(messages)
     );
   }

--- a/src/herumi/signature.ts
+++ b/src/herumi/signature.ts
@@ -2,7 +2,7 @@ import type {SignatureType} from "bls-eth-wasm";
 import {getContext} from "./context.js";
 import {PublicKey} from "./publicKey.js";
 import {bytesToHex, concatUint8Arrays, hexToBytes, isZeroUint8Array} from "../helpers/index.js";
-import {PointFormat, Signature as ISignature, CoordType} from "../types.js";
+import {SignatureSet, PointFormat, Signature as ISignature, CoordType} from "../types.js";
 import {EmptyAggregateError, InvalidLengthError, InvalidOrderError} from "../errors.js";
 import {SIGNATURE_LENGTH_COMPRESSED, SIGNATURE_LENGTH_UNCOMPRESSED} from "../constants.js";
 
@@ -52,13 +52,22 @@ export class Signature implements ISignature {
     return new Signature(signature);
   }
 
-  static verifyMultipleSignatures(sets: {publicKey: PublicKey; message: Uint8Array; signature: Signature}[]): boolean {
+  static verifyMultipleSignatures(sets: SignatureSet[]): boolean {
     const context = getContext();
     return context.multiVerify(
       sets.map((s) => s.publicKey.value),
       sets.map((s) => s.signature.value),
       sets.map((s) => s.message)
     );
+  }
+
+  static async asyncVerifyMultipleSignatures(sets: SignatureSet[]): Promise<boolean> {
+    // eslint-disable-next-line no-console
+    console.log(
+      "asyncVerifyMultipleSignatures is not implemented by bls-eth-wasm.\n" +
+        "Please use the synchronous Signature.verifyMultipleSignatures instead"
+    );
+    return Signature.verifyMultipleSignatures(sets);
   }
 
   verify(publicKey: PublicKey, message: Uint8Array): boolean {
@@ -77,6 +86,30 @@ export class Signature implements ISignature {
       publicKeys.map((key) => key.value),
       concatUint8Arrays(messages)
     );
+  }
+
+  async asyncVerify(publicKey: PublicKey, message: Uint8Array): Promise<boolean> {
+    // eslint-disable-next-line no-console
+    console.log("asyncVerify is not implemented by bls-eth-wasm.\nPlease use the synchronous Signature.verify instead");
+    return this.verify(publicKey, message);
+  }
+
+  async asyncVerifyAggregate(publicKeys: PublicKey[], message: Uint8Array): Promise<boolean> {
+    // eslint-disable-next-line no-console
+    console.log(
+      "asyncVerifyAggregate is not implemented by bls-eth-wasm.\n" +
+        "Please use the synchronous Signature.verifyAggregate instead"
+    );
+    return this.verifyAggregate(publicKeys, message);
+  }
+
+  async asyncVerifyMultiple(publicKeys: PublicKey[], messages: Uint8Array[]): Promise<boolean> {
+    // eslint-disable-next-line no-console
+    console.log(
+      "asyncVerifyMultiple is not implemented by bls-eth-wasm.\n" +
+        "Please use the synchronous Signature.verifyMultiple instead"
+    );
+    return this.verifyMultiple(publicKeys, messages);
   }
 
   toBytes(format?: PointFormat): Uint8Array {

--- a/src/herumi/signature.ts
+++ b/src/herumi/signature.ts
@@ -78,7 +78,7 @@ export class Signature implements ISignature {
       validateBytes(signature, "signature");
       sig = Signature.fromBytes(signature);
     } else {
-      // need to cast to herumi key instead of ISignature
+      // need to cast to herumi sig instead of ISignature
       sig = signature as Signature;
     }
     return sig.value;

--- a/src/herumi/signature.ts
+++ b/src/herumi/signature.ts
@@ -64,11 +64,6 @@ export class Signature implements ISignature {
   }
 
   static async asyncVerifyMultipleSignatures(sets: SignatureSet[]): Promise<boolean> {
-    // eslint-disable-next-line no-console
-    console.log(
-      "asyncVerifyMultipleSignatures is not implemented by bls-eth-wasm.\n" +
-        "Please use the synchronous Signature.verifyMultipleSignatures instead"
-    );
     return Signature.verifyMultipleSignatures(sets);
   }
 
@@ -111,26 +106,14 @@ export class Signature implements ISignature {
   }
 
   async asyncVerify(publicKey: PublicKey, message: Uint8Array): Promise<boolean> {
-    // eslint-disable-next-line no-console
-    console.log("asyncVerify is not implemented by bls-eth-wasm.\nPlease use the synchronous Signature.verify instead");
     return this.verify(publicKey, message);
   }
 
   async asyncVerifyAggregate(publicKeys: PublicKey[], message: Uint8Array): Promise<boolean> {
-    // eslint-disable-next-line no-console
-    console.log(
-      "asyncVerifyAggregate is not implemented by bls-eth-wasm.\n" +
-        "Please use the synchronous Signature.verifyAggregate instead"
-    );
     return this.verifyAggregate(publicKeys, message);
   }
 
   async asyncVerifyMultiple(publicKeys: PublicKey[], messages: Uint8Array[]): Promise<boolean> {
-    // eslint-disable-next-line no-console
-    console.log(
-      "asyncVerifyMultiple is not implemented by bls-eth-wasm.\n" +
-        "Please use the synchronous Signature.verifyMultiple instead"
-    );
     return this.verifyMultiple(publicKeys, messages);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,17 +35,59 @@ export interface IBls {
   PublicKey: typeof PublicKey;
   Signature: typeof Signature;
 
+  secretKeyToPublicKey(secretKey: Uint8Array): Uint8Array;
   sign(secretKey: Uint8Array, message: Uint8Array): Uint8Array;
   aggregatePublicKeys(publicKeys: PublicKeyArg[]): Uint8Array;
   aggregateSignatures(signatures: SignatureArg[]): Uint8Array;
+  /**
+   * Will synchronously verify a signature. This function catches invalid input and return false for
+   * bad keys or signatures. Use the `Signature.verify` method if throwing is desired.
+   */
   verify(publicKey: PublicKeyArg, message: Uint8Array, signature: SignatureArg): boolean;
+  /**
+   * Will synchronously verify a signature over a message by multiple aggregated keys. This function
+   * catches invalid input and return false for bad keys or signatures. Use the
+   * `Signature.verifyAggregate` if throwing is desired.
+   */
   verifyAggregate(publicKeys: PublicKeyArg[], message: Uint8Array, signature: SignatureArg): boolean;
+  /**
+   * Will synchronously verify an aggregated signature over a number of messages each signed by a
+   * different key. This function catches invalid input and return false for bad keys or signatures.
+   * Use the `Signature.verifyAggregate` if throwing is desired.
+   *
+   * Note: the number of keys and messages must match.
+   */
   verifyMultiple(publicKeys: PublicKeyArg[], messages: Uint8Array[], signature: SignatureArg): boolean;
+  /**
+   * Will synchronously verify a group of SignatureSets where each contains a signature signed for
+   * a message by a public key. This function catches invalid input and return false for bad keys or
+   * signatures. Use the `Signature.verifyMultipleSignatures` if throwing is desired.
+   */
   verifyMultipleSignatures(sets: SignatureSet[]): boolean;
-  secretKeyToPublicKey(secretKey: Uint8Array): Uint8Array;
+  /**
+   * Will asynchronously verify a signature. This function catches invalid input and return false for
+   * bad keys or signatures. Use the `Signature.asyncVerify` method if throwing is desired.
+   */
   asyncVerify(publicKey: PublicKeyArg, message: Uint8Array, signature: SignatureArg): Promise<boolean>;
+  /**
+   * Will asynchronously verify a signature over a message by multiple aggregated keys. This function
+   * catches invalid input and return false for bad keys or signatures. Use the
+   * `Signature.asyncVerifyAggregate` if throwing is desired.
+   */
   asyncVerifyAggregate(publicKeys: PublicKeyArg[], message: Uint8Array, signature: SignatureArg): Promise<boolean>;
+  /**
+   * Will asynchronously verify an aggregated signature over a number of messages each signed by a
+   * different key. This function catches invalid input and return false for bad keys or signatures.
+   * Use the `Signature.asyncVerifyAggregate` if throwing is desired.
+   *
+   * Note: the number of keys and messages must match.
+   */
   asyncVerifyMultiple(publicKeys: PublicKeyArg[], messages: Uint8Array[], signature: SignatureArg): Promise<boolean>;
+  /**
+   * Will asynchronously verify a group of SignatureSets where each contains a signature signed for
+   * a message by a public key. This function catches invalid input and return false for bad keys or
+   * signatures. Use the Signature.asyncVerifyMultipleSignatures if throwing is desired.
+   */
   asyncVerifyMultipleSignatures(sets: SignatureSet[]): Promise<boolean>;
 }
 
@@ -67,7 +109,7 @@ export declare class PublicKey {
   /** @param type Only for impl `blst-native`. Defaults to `CoordType.jacobian` */
   static fromBytes(bytes: Uint8Array, type?: CoordType, validate?: boolean): PublicKey;
   static fromHex(hex: string): PublicKey;
-  static aggregate(publicKeys: PublicKey[]): PublicKey;
+  static aggregate(publicKeys: PublicKeyArg[]): PublicKey;
   /** @param format Defaults to `PointFormat.compressed` */
   toBytes(format?: PointFormat): Uint8Array;
   toHex(format?: PointFormat): string;
@@ -81,16 +123,60 @@ export declare class Signature {
    *  @param validate When using `herumi` implementation, signature validation is always on regardless of this flag. */
   static fromBytes(bytes: Uint8Array, type?: CoordType, validate?: boolean): Signature;
   static fromHex(hex: string): Signature;
-  static aggregate(signatures: Signature[]): Signature;
+  static aggregate(signatures: SignatureArg[]): Signature;
+  /**
+   * Will synchronously verify a group of SignatureSets where each contains a signature signed for
+   * a message by a public key. This version of the function will potentially throw errors for
+   * invalid input. Use the free function `verifyMultipleSignatures` if throwing is not desired.
+   */
   static verifyMultipleSignatures(sets: SignatureSet[]): boolean;
+  /**
+   * Will asynchronously verify a group of SignatureSets where each contains a signature signed for
+   * a message by a public key. This version of the function will potentially throw errors for
+   * invalid input. Use the free function `verifyMultipleSignatures` if throwing is not desired.
+   */
   static asyncVerifyMultipleSignatures(sets: SignatureSet[]): Promise<boolean>;
-  verify(publicKey: PublicKey, message: Uint8Array): boolean;
-  verifyAggregate(publicKeys: PublicKey[], message: Uint8Array): boolean;
-  verifyMultiple(publicKeys: PublicKey[], messages: Uint8Array[]): boolean;
+  /**
+   * Will synchronously verify a signature. This version of the function will potentially throw
+   * errors for invalid input. Use the free function `verify` if throwing is not desired.
+   */
+  verify(publicKey: PublicKeyArg, message: Uint8Array): boolean;
+  /**
+   * Will synchronously verify a signature over a message by multiple aggregated keys.  This
+   * version of the function will potentially throw errors for invalid input. Use the free function
+   * `verifyAggregate` if throwing is not desired.
+   */
+  verifyAggregate(publicKeys: PublicKeyArg[], message: Uint8Array): boolean;
+  /**
+   * Will synchronously verify an aggregated signature over a number of messages each signed by a
+   * different key. This version of the function will potentially throw errors for invalid input.
+   * Use the free function `verifyMultiple` if throwing is not desired.
+   *
+   * Note: the number of keys and messages must match.
+   */
+  verifyMultiple(publicKeys: PublicKeyArg[], messages: Uint8Array[]): boolean;
+  /**
+   * Will asynchronously verify a signature.  This version of the function will potentially throw
+   * errors for invalid input. Use the free function `asyncVerify` if throwing is not desired.
+   */
   asyncVerify(publicKey: PublicKeyArg, message: Uint8Array): Promise<boolean>;
+  /**
+   * Will asynchronously verify a signature over a message by multiple aggregated keys.  This
+   * version of the function will potentially throw errors for invalid input. Use the free function
+   * `asyncVerifyAggregate` if throwing is not desired.
+   */
   asyncVerifyAggregate(publicKeys: PublicKeyArg[], message: Uint8Array): Promise<boolean>;
+  /**
+   * Will asynchronously verify an aggregated signature over a number of messages each signed by a
+   * different key. This version of the function will potentially throw errors for invalid input.
+   * Use the free function `asyncVerifyMultiple` if throwing is not desired.
+   *
+   * Note: the number of keys and messages must match.
+   */
   asyncVerifyMultiple(publicKeys: PublicKeyArg[], messages: Uint8Array[]): Promise<boolean>;
-  /** @param format Defaults to `PointFormat.compressed` */
+  /**
+   * @default format - `PointFormat.compressed`
+   */
   toBytes(format?: PointFormat): Uint8Array;
   toHex(format?: PointFormat): string;
   multiplyBy(bytes: Uint8Array): Signature;

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,10 +82,14 @@ export declare class Signature {
   static fromBytes(bytes: Uint8Array, type?: CoordType, validate?: boolean): Signature;
   static fromHex(hex: string): Signature;
   static aggregate(signatures: Signature[]): Signature;
-  static verifyMultipleSignatures(sets: {publicKey: PublicKey; message: Uint8Array; signature: Signature}[]): boolean;
+  static verifyMultipleSignatures(sets: SignatureSet[]): boolean;
+  static asyncVerifyMultipleSignatures(sets: SignatureSet[]): Promise<boolean>;
   verify(publicKey: PublicKey, message: Uint8Array): boolean;
   verifyAggregate(publicKeys: PublicKey[], message: Uint8Array): boolean;
   verifyMultiple(publicKeys: PublicKey[], messages: Uint8Array[]): boolean;
+  asyncVerify(publicKey: PublicKeyArg, message: Uint8Array): Promise<boolean>;
+  asyncVerifyAggregate(publicKeys: PublicKeyArg[], message: Uint8Array): Promise<boolean>;
+  asyncVerifyMultiple(publicKeys: PublicKeyArg[], messages: Uint8Array[]): Promise<boolean>;
   /** @param format Defaults to `PointFormat.compressed` */
   toBytes(format?: PointFormat): Uint8Array;
   toHex(format?: PointFormat): string;

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -1,4 +1,3 @@
-const path = require('path');
 const ResolveTypeScriptPlugin = require("resolve-typescript-plugin");
 
 module.exports = {
@@ -10,10 +9,6 @@ module.exports = {
   module: {
     rules: [
       {test: /\.(ts)$/, use: {loader: "ts-loader", options: {transpileOnly: true}}},
-      {
-        test: /@chainsafe\/blst/,
-        use: 'null-loader',
-      },
     ],
   },
   optimization: {
@@ -28,12 +23,12 @@ module.exports = {
     ],
     alias: {
       "crypto": "crypto-browserify",
-      './blst-native/index.js': path.resolve(__dirname, './src/herumi/index.js')
     },
     fallback: {
       fs: false,
       path: false,
       stream: false,
+      child_process: false,
     },
   },
   experiments: {


### PR DESCRIPTION
There was a hard import of `@chainsafe/blst` at the head of `functional.ts` that was causing issues with tree shaking.

- Removed implementation specific code from isomorphic files
- Made async versions of the functions on the respective class interfaces
- Widened types to allow both serialized and deserialized objects as function arguments
- Moved herumi specific implementation details into the herumi classes
- Moved blst-native specific implementation details into the blst-native classes
- Re-implemented functional.ts to take advantage of the above and simplify the isomorphic code
- Remove webpack config that was added because of the unnoticed import of blst to get the web tests to work
- Minor version bump because some types on public API were widened.  Non-breaking though and also not a patch methinks