### PR TITLE
feat!: simplify interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [9.0.0] - TODO
 
-- TODO
+### Features
+
+- simplify interface [#182](https://github.com/ChainSafe/bls/pull/182)
 
 ## [7.1.1] - 2022-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.0] - TODO
+
+- TODO
+
 ## [7.1.1] - 2022-05-15
 
 ### Chores

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ yarn add @chainsafe/bls @chainsafe/blst
 
 By default, native bindings will be used if in NodeJS and they are installed. A WASM implementation ("herumi") is used as a fallback in case any error occurs.
 
-The `blst-native` implementation offers a multi-threaded approach to verification and utilizes the libuv worker pool to verification.  It is a more performant options synchronously and FAR better when utilized asynchronously.  All verification functions provide sync and async versions.  Both the `blst-native` and `herumi` implementations offer verification functions with `async` prefixes as free functions and also on their respective classes. This was done to preserve the isomorphic architecture of this library. In reality however, only the `blst-native` bindings have the ability to implement a promise based approach. In the `herumi` version the async version just proxies to the sync version under the hood.
-
 ```ts
 import bls from "@chainsafe/bls";
 

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -23,6 +23,7 @@ module.exports = function (config) {
       resolve: webpackConfig.resolve,
       experiments: webpackConfig.experiments,
       optimization: webpackConfig.optimization,
+      externals: webpackConfig.externals,
       stats: {warnings:false},
     },
     reporters: ["spec"],

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "v8-profiler-next": "1.10.0"
   },
   "peerDependencies": {
-    "@chainsafe/blst": "^1.0.0"
+    "@chainsafe/blst": "^2.0.1"
   },
   "peerDependenciesMeta": {
     "@chainsafe/blst": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/bls",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "description": "Implementation of bls signature verification for ethereum 2.0",
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "bls-eth-wasm": "^1.1.1"
   },
   "devDependencies": {
-    "@chainsafe/blst": "^1.0.0",
+    "@chainsafe/blst": "^2.0.1",
     "@chainsafe/eslint-plugin-node": "^11.2.3",
     "@chainsafe/threads": "^1.9.0",
     "@lodestar/spec-test-util": "1.13.0",

--- a/src/blst-native/publicKey.ts
+++ b/src/blst-native/publicKey.ts
@@ -1,53 +1,32 @@
 import blst from "@chainsafe/blst";
 import {EmptyAggregateError} from "../errors.js";
-import {bytesToHex, hexToBytes} from "../helpers/index.js";
-import {CoordType, PointFormat, PublicKey as IPublicKey, PublicKeyArg} from "../types.js";
+import {PublicKey as IPublicKey} from "../types.js";
 
 export class PublicKey implements IPublicKey {
-  private constructor(private readonly value: blst.PublicKey) {}
+  constructor(private readonly value: blst.PublicKey) {}
 
-  /** @param type Defaults to `CoordType.jacobian` */
-  static fromBytes(bytes: Uint8Array, type?: CoordType, validate = true): PublicKey {
-    // need to hack the CoordType so @chainsafe/blst is not a required dep
-    const pk = blst.PublicKey.deserialize(bytes, (type as unknown) as blst.CoordType);
-    if (validate) pk.keyValidate();
-    return new PublicKey(pk);
+  static fromBytes(bytes: Uint8Array, validate = true): PublicKey {
+    return new PublicKey(blst.PublicKey.fromBytes(bytes, validate));
   }
 
-  static fromHex(hex: string): PublicKey {
-    return this.fromBytes(hexToBytes(hex));
+  static fromHex(hex: string, validate = true): PublicKey {
+    return new PublicKey(blst.PublicKey.fromHex(hex, validate));
   }
 
-  static aggregate(publicKeys: PublicKeyArg[]): PublicKey {
+  static aggregate(publicKeys: PublicKey[]): PublicKey {
     if (publicKeys.length === 0) {
       throw new EmptyAggregateError();
     }
 
-    const pk = blst.aggregatePublicKeys(publicKeys.map(PublicKey.convertToBlstPublicKeyArg));
+    const pk = blst.aggregatePublicKeys(publicKeys.map((pk) => (pk as PublicKey).value));
     return new PublicKey(pk);
   }
 
-  static convertToBlstPublicKeyArg(publicKey: PublicKeyArg): blst.PublicKeyArg {
-    // need to cast to blst-native key instead of IPublicKey
-    return publicKey instanceof Uint8Array ? publicKey : (publicKey as PublicKey).value;
+  toBytes(compress = true): Uint8Array {
+    return this.value.toBytes(compress);
   }
 
-  /**
-   * Implemented for SecretKey to be able to call .toPublicKey()
-   */
-  private static friendBuild(key: blst.PublicKey): PublicKey {
-    return new PublicKey(key);
-  }
-
-  toBytes(format?: PointFormat): Uint8Array {
-    if (format === PointFormat.uncompressed) {
-      return this.value.serialize(false);
-    } else {
-      return this.value.serialize(true);
-    }
-  }
-
-  toHex(format?: PointFormat): string {
-    return bytesToHex(this.toBytes(format));
+  toHex(compress = true): string {
+    return this.value.toHex(compress);
   }
 }

--- a/src/blst-native/publicKey.ts
+++ b/src/blst-native/publicKey.ts
@@ -50,8 +50,4 @@ export class PublicKey implements IPublicKey {
   toHex(format?: PointFormat): string {
     return bytesToHex(this.toBytes(format));
   }
-
-  multiplyBy(bytes: Uint8Array): PublicKey {
-    return new PublicKey(this.value.multiplyBy(bytes));
-  }
 }

--- a/src/blst-native/secretKey.ts
+++ b/src/blst-native/secretKey.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import blst from "@chainsafe/blst";
 import {SecretKey as ISecretKey} from "../types.js";
 import {PublicKey} from "./publicKey.js";

--- a/src/blst-native/secretKey.ts
+++ b/src/blst-native/secretKey.ts
@@ -20,8 +20,8 @@ export class SecretKey implements ISecretKey {
     return new SecretKey(blst.SecretKey.fromHex(hex));
   }
 
-  static fromKeygen(entropy: Uint8Array): SecretKey {
-    return new SecretKey(blst.SecretKey.fromKeygen(entropy));
+  static fromKeygen(entropy?: Uint8Array): SecretKey {
+    return new SecretKey(blst.SecretKey.fromKeygen(entropy ?? crypto.getRandomValues(new Uint8Array(32))));
   }
 
   sign(message: Uint8Array): Signature {

--- a/src/blst-native/secretKey.ts
+++ b/src/blst-native/secretKey.ts
@@ -1,50 +1,42 @@
 import blst from "@chainsafe/blst";
-import crypto from "crypto";
-import {bytesToHex, hexToBytes, isZeroUint8Array} from "../helpers/index.js";
-import {SECRET_KEY_LENGTH} from "../constants.js";
 import {SecretKey as ISecretKey} from "../types.js";
 import {PublicKey} from "./publicKey.js";
 import {Signature} from "./signature.js";
+import {isZeroUint8Array} from "../helpers/utils.js";
 import {ZeroSecretKeyError} from "../errors.js";
 
 export class SecretKey implements ISecretKey {
   constructor(private readonly value: blst.SecretKey) {}
 
   static fromBytes(bytes: Uint8Array): SecretKey {
-    // draft-irtf-cfrg-bls-signature-04 does not allow SK == 0
     if (isZeroUint8Array(bytes)) {
       throw new ZeroSecretKeyError();
     }
 
-    const sk = blst.SecretKey.deserialize(bytes);
-    return new SecretKey(sk);
+    return new SecretKey(blst.SecretKey.fromBytes(bytes));
   }
 
   static fromHex(hex: string): SecretKey {
-    return this.fromBytes(hexToBytes(hex));
+    return new SecretKey(blst.SecretKey.fromHex(hex));
   }
 
-  static fromKeygen(entropy?: Uint8Array): SecretKey {
-    const sk = blst.SecretKey.fromKeygen(entropy || crypto.randomBytes(SECRET_KEY_LENGTH));
-    return new SecretKey(sk);
+  static fromKeygen(entropy: Uint8Array): SecretKey {
+    return new SecretKey(blst.SecretKey.fromKeygen(entropy));
   }
 
   sign(message: Uint8Array): Signature {
-    // @ts-expect-error Need to hack private constructor with static method
-    return Signature.friendBuild(this.value.sign(message));
+    return new Signature(this.value.sign(message));
   }
 
   toPublicKey(): PublicKey {
-    const pk = this.value.toPublicKey();
-    // @ts-expect-error Need to hack private constructor with static method
-    return PublicKey.friendBuild(pk);
+    return new PublicKey(this.value.toPublicKey());
   }
 
   toBytes(): Uint8Array {
-    return this.value.serialize();
+    return this.value.toBytes();
   }
 
   toHex(): string {
-    return bytesToHex(this.toBytes());
+    return this.value.toHex();
   }
 }

--- a/src/blst-native/signature.ts
+++ b/src/blst-native/signature.ts
@@ -1,105 +1,65 @@
 import blst from "@chainsafe/blst";
-import {bytesToHex, hexToBytes} from "../helpers/index.js";
-import {SignatureSet, CoordType, PointFormat, Signature as ISignature, PublicKeyArg, SignatureArg} from "../types.js";
+import {SignatureSet, Signature as ISignature} from "../types.js";
 import {PublicKey} from "./publicKey.js";
-import {EmptyAggregateError, ZeroSignatureError} from "../errors.js";
+import {EmptyAggregateError} from "../errors.js";
 
 export class Signature implements ISignature {
-  private constructor(private readonly value: blst.Signature) {}
+  constructor(private readonly value: blst.Signature) {}
 
-  /** @param type Defaults to `CoordType.affine` */
-  static fromBytes(bytes: Uint8Array, type?: CoordType, validate = true): Signature {
-    // need to hack the CoordType so @chainsafe/blst is not a required dep
-    const sig = blst.Signature.deserialize(bytes, (type as unknown) as blst.CoordType);
-    if (validate) sig.sigValidate();
-    return new Signature(sig);
+  static fromBytes(bytes: Uint8Array, validate = true): Signature {
+    return new Signature(blst.Signature.fromBytes(bytes, validate, false));
   }
 
-  static fromHex(hex: string): Signature {
-    return this.fromBytes(hexToBytes(hex));
+  static fromHex(hex: string, validate = true): Signature {
+    return new Signature(blst.Signature.fromHex(hex, validate, false));
   }
 
-  static aggregate(signatures: SignatureArg[]): Signature {
+  static aggregate(signatures: Signature[]): Signature {
     if (signatures.length === 0) {
       throw new EmptyAggregateError();
     }
 
-    const agg = blst.aggregateSignatures(signatures.map(Signature.convertToBlstSignatureArg));
+    const agg = blst.aggregateSignatures(signatures.map((sig) => sig.value));
     return new Signature(agg);
   }
 
   static verifyMultipleSignatures(sets: SignatureSet[]): boolean {
     return blst.verifyMultipleAggregateSignatures(
       sets.map((set) => ({
-        message: set.message,
-        publicKey: PublicKey.convertToBlstPublicKeyArg(set.publicKey),
-        signature: Signature.convertToBlstSignatureArg(set.signature),
-      }))
+        msg: set.message,
+        pk: (set.publicKey as PublicKey)["value"],
+        sig: (set.signature as Signature)["value"],
+      })),
+      true,
+      true
     );
   }
 
-  static convertToBlstSignatureArg(signature: SignatureArg): blst.SignatureArg {
-    // Need to cast to blst-native Signature instead of ISignature
-    return signature instanceof Uint8Array ? signature : (signature as Signature).value;
+  verify(publicKey: PublicKey, message: Uint8Array): boolean {
+    return blst.verify(message, publicKey["value"], this.value);
   }
 
-  /**
-   * Implemented for SecretKey to be able to call .sign()
-   */
-  private static friendBuild(sig: blst.Signature): Signature {
-    return new Signature(sig);
+  verifyAggregate(publicKeys: PublicKey[], message: Uint8Array): boolean {
+    return blst.fastAggregateVerify(
+      message,
+      publicKeys.map((pk) => pk["value"]),
+      this.value
+    );
   }
 
-  verify(publicKey: PublicKeyArg, message: Uint8Array): boolean {
-    // TODO (@matthewkeil) The note in aggregateVerify and the checks in this method
-    // do not seem to go together. Need to check the spec further.
-
-    // Individual infinity signatures are NOT okay. Aggregated signatures MAY be infinity
-    if (this.value.isInfinity()) {
-      throw new ZeroSignatureError();
-    }
-    return blst.verify(message, PublicKey.convertToBlstPublicKeyArg(publicKey), this.value);
+  verifyMultiple(publicKeys: PublicKey[], messages: Uint8Array[]): boolean {
+    return blst.aggregateVerify(
+      messages,
+      publicKeys.map((pk) => pk["value"]),
+      this.value
+    );
   }
 
-  verifyAggregate(publicKeys: PublicKeyArg[], message: Uint8Array): boolean {
-    return blst.fastAggregateVerify(message, publicKeys.map(PublicKey.convertToBlstPublicKeyArg), this.value);
+  toBytes(compress = true): Uint8Array {
+    return this.value.toBytes(compress);
   }
 
-  verifyMultiple(publicKeys: PublicKeyArg[], messages: Uint8Array[]): boolean {
-    return this.aggregateVerify(publicKeys, messages);
-  }
-
-  toBytes(format?: PointFormat): Uint8Array {
-    if (format === PointFormat.uncompressed) {
-      return this.value.serialize(false);
-    } else {
-      return this.value.serialize(true);
-    }
-  }
-
-  toHex(format?: PointFormat): string {
-    return bytesToHex(this.toBytes(format));
-  }
-
-  private aggregateVerify(publicKeys: PublicKeyArg[], messages: Uint8Array[]): boolean {
-    // TODO (@matthewkeil) The note in verify and the checks in this method
-    // do not seem to go together. Need to check the spec further.
-
-    // If this set is simply an infinity signature and infinity publicKey then skip verification.
-    // This has the effect of always declaring that this sig/publicKey combination is valid.
-    // for Eth2.0 specs tests
-    if (publicKeys.length === 1) {
-      const publicKey = publicKeys[0];
-      // eslint-disable-next-line prettier/prettier
-      const pk: PublicKey = publicKey instanceof Uint8Array 
-        ? PublicKey.fromBytes(publicKey) 
-        : (publicKey as PublicKey); // need to cast to blst-native key instead of IPublicKey
-      // @ts-expect-error Need to hack type to get access to the private `value`
-      if (this.value.isInfinity() && pk.value.isInfinity()) {
-        return runAsync ? Promise.resolve(true) : true;
-      }
-    }
-
-    return blst.aggregateVerify(messages, publicKeys.map(PublicKey.convertToBlstPublicKeyArg), this.value);
+  toHex(compress = true): string {
+    return this.value.toHex(compress);
   }
 }

--- a/src/functional.ts
+++ b/src/functional.ts
@@ -125,77 +125,6 @@ export function functionalInterfaceFactory({
   }
 
   /**
-   * Verifies if signature is message signed with given public key.
-   */
-  async function asyncVerify(publicKey: PublicKeyArg, message: Uint8Array, signature: SignatureArg): Promise<boolean> {
-    if (implementation === "herumi") return verify(publicKey, message, signature);
-    try {
-      // must be in try/catch in case sig is invalid
-      const sig = signature instanceof Signature ? signature : Signature.fromBytes(signature);
-      return await sig.asyncVerify(publicKey, message);
-    } catch (e) {
-      if (e instanceof NotInitializedError) throw e;
-      return false;
-    }
-  }
-
-  /**
-   * Verifies if aggregated signature is same message signed with given public keys.
-   */
-  async function asyncVerifyAggregate(
-    publicKeys: PublicKeyArg[],
-    message: Uint8Array,
-    signature: SignatureArg
-  ): Promise<boolean> {
-    if (implementation === "herumi") return verifyAggregate(publicKeys, message, signature);
-    try {
-      const sig = signature instanceof Signature ? signature : Signature.fromBytes(signature);
-      return await sig.asyncVerifyAggregate(publicKeys, message);
-    } catch (e) {
-      if (e instanceof NotInitializedError) throw e;
-      return false;
-    }
-  }
-
-  /**
-   * Verifies if signature is list of message signed with corresponding public key.
-   */
-  async function asyncVerifyMultiple(
-    publicKeys: PublicKeyArg[],
-    messages: Uint8Array[],
-    signature: SignatureArg
-  ): Promise<boolean> {
-    if (implementation === "herumi") return verifyMultiple(publicKeys, messages, signature);
-    try {
-      const sig = signature instanceof Signature ? signature : Signature.fromBytes(signature);
-      return await sig.asyncVerifyMultiple(publicKeys, messages);
-    } catch (e) {
-      if (e instanceof NotInitializedError) throw e;
-      return false;
-    }
-  }
-
-  /**
-   * Verifies multiple signatures at once returning true if all valid or false
-   * if at least one is not. Optimization useful when knowing which signature is
-   * wrong is not relevant, i.e. verifying an entire Eth2.0 block.
-   *
-   * This method provides a safe way to do so by multiplying each signature by
-   * a random number so an attacker cannot craft a malicious signature that won't
-   * verify on its own but will if it's added to a specific predictable signature
-   * https://ethresear.ch/t/fast-verification-of-multiple-bls-signatures/5407
-   */
-  async function asyncVerifyMultipleSignatures(sets: SignatureSet[]): Promise<boolean> {
-    try {
-      if (implementation === "herumi") return Signature.verifyMultipleSignatures(sets);
-      return await Signature.asyncVerifyMultipleSignatures(sets);
-    } catch (e) {
-      if (e instanceof NotInitializedError) throw e;
-      return false;
-    }
-  }
-
-  /**
    * Computes a public key from a secret key
    */
   function secretKeyToPublicKey(secretKey: Uint8Array): Uint8Array {
@@ -208,13 +137,9 @@ export function functionalInterfaceFactory({
     aggregateSignatures,
     aggregatePublicKeys,
     verify,
-    asyncVerify,
     verifyAggregate,
-    asyncVerifyAggregate,
     verifyMultiple,
-    asyncVerifyMultiple,
     verifyMultipleSignatures,
-    asyncVerifyMultipleSignatures,
     secretKeyToPublicKey,
   };
 }

--- a/src/functional.ts
+++ b/src/functional.ts
@@ -123,11 +123,13 @@ export function functionalInterfaceFactory({
    */
   function verifyMultipleSignatures(sets: SerializedSignatureSet[]): boolean {
     try {
-      return Signature.verifyMultipleSignatures(sets.map((set) => ({
-        message: set.message,
-        publicKey: PublicKey.fromBytes(set.publicKey),
-        signature: Signature.fromBytes(set.signature),
-      })));
+      return Signature.verifyMultipleSignatures(
+        sets.map((set) => ({
+          message: set.message,
+          publicKey: PublicKey.fromBytes(set.publicKey),
+          signature: Signature.fromBytes(set.signature),
+        }))
+      );
     } catch (e) {
       if (e instanceof NotInitializedError) throw e;
       return false;

--- a/src/herumi/publicKey.ts
+++ b/src/herumi/publicKey.ts
@@ -70,13 +70,4 @@ export class PublicKey implements IPublicKey {
   toHex(format?: PointFormat): string {
     return bytesToHex(this.toBytes(format));
   }
-
-  multiplyBy(_bytes: Uint8Array): PublicKey {
-    // TODO: I found this in the code but its not exported. Need to figure out
-    //       how to implement
-    // const a = getContext();
-    // const randomness = new a.FR(8);
-    // return new PublicKey(a.mul(this.value, randomness));
-    throw new Error("multiplyBy is not implemented by bls-eth-wasm");
-  }
 }

--- a/src/herumi/secretKey.ts
+++ b/src/herumi/secretKey.ts
@@ -1,5 +1,5 @@
 import type {SecretKeyType} from "bls-eth-wasm";
-import {generateRandomSecretKey} from "@chainsafe/bls-keygen";
+import {deriveKeyFromEntropy} from "@chainsafe/bls-keygen";
 import {SECRET_KEY_LENGTH} from "../constants.js";
 import {getContext} from "./context.js";
 import {PublicKey} from "./publicKey.js";
@@ -34,8 +34,8 @@ export class SecretKey implements ISecretKey {
     return this.fromBytes(hexToBytes(hex));
   }
 
-  static fromKeygen(entropy?: Uint8Array): SecretKey {
-    const sk = generateRandomSecretKey(entropy);
+  static fromKeygen(entropy: Uint8Array): SecretKey {
+    const sk = deriveKeyFromEntropy(entropy);
     return this.fromBytes(sk);
   }
 

--- a/src/herumi/secretKey.ts
+++ b/src/herumi/secretKey.ts
@@ -1,5 +1,5 @@
 import type {SecretKeyType} from "bls-eth-wasm";
-import {deriveKeyFromEntropy} from "@chainsafe/bls-keygen";
+import {deriveKeyFromEntropy, generateRandomSecretKey} from "@chainsafe/bls-keygen";
 import {SECRET_KEY_LENGTH} from "../constants.js";
 import {getContext} from "./context.js";
 import {PublicKey} from "./publicKey.js";
@@ -34,8 +34,8 @@ export class SecretKey implements ISecretKey {
     return this.fromBytes(hexToBytes(hex));
   }
 
-  static fromKeygen(entropy: Uint8Array): SecretKey {
-    const sk = deriveKeyFromEntropy(entropy);
+  static fromKeygen(entropy?: Uint8Array): SecretKey {
+    const sk = entropy ? deriveKeyFromEntropy(entropy) : generateRandomSecretKey();
     return this.fromBytes(sk);
   }
 

--- a/src/herumi/signature.ts
+++ b/src/herumi/signature.ts
@@ -63,10 +63,6 @@ export class Signature implements ISignature {
     );
   }
 
-  static async asyncVerifyMultipleSignatures(sets: SignatureSet[]): Promise<boolean> {
-    return Signature.verifyMultipleSignatures(sets);
-  }
-
   static convertToSignatureType(signature: SignatureArg): SignatureType {
     let sig: Signature;
     if (signature instanceof Uint8Array) {
@@ -105,18 +101,6 @@ export class Signature implements ISignature {
     );
   }
 
-  async asyncVerify(publicKey: PublicKey, message: Uint8Array): Promise<boolean> {
-    return this.verify(publicKey, message);
-  }
-
-  async asyncVerifyAggregate(publicKeys: PublicKey[], message: Uint8Array): Promise<boolean> {
-    return this.verifyAggregate(publicKeys, message);
-  }
-
-  async asyncVerifyMultiple(publicKeys: PublicKey[], messages: Uint8Array[]): Promise<boolean> {
-    return this.verifyMultiple(publicKeys, messages);
-  }
-
   toBytes(format?: PointFormat): Uint8Array {
     if (format === PointFormat.uncompressed) {
       return this.value.serializeUncompressed();
@@ -127,14 +111,5 @@ export class Signature implements ISignature {
 
   toHex(format?: PointFormat): string {
     return bytesToHex(this.toBytes(format));
-  }
-
-  multiplyBy(_bytes: Uint8Array): Signature {
-    // TODO: I found this in the code but its not exported. Need to figure out
-    //       how to implement
-    // const a = getContext();
-    // const randomness = new a.FR(8);
-    // return new Signature(a.mul(this.value, randomness));
-    throw new Error("multiplyBy is not implemented by bls-eth-wasm");
   }
 }

--- a/src/herumi/signature.ts
+++ b/src/herumi/signature.ts
@@ -2,7 +2,7 @@ import type {SignatureType} from "bls-eth-wasm";
 import {getContext} from "./context.js";
 import {PublicKey} from "./publicKey.js";
 import {bytesToHex, concatUint8Arrays, hexToBytes, isZeroUint8Array, validateBytes} from "../helpers/index.js";
-import {SignatureSet, PointFormat, Signature as ISignature, CoordType, PublicKeyArg, SignatureArg} from "../types.js";
+import {SignatureSet, Signature as ISignature} from "../types.js";
 import {EmptyAggregateError, InvalidLengthError, InvalidOrderError} from "../errors.js";
 import {SIGNATURE_LENGTH_COMPRESSED, SIGNATURE_LENGTH_UNCOMPRESSED} from "../constants.js";
 
@@ -18,10 +18,9 @@ export class Signature implements ISignature {
   }
 
   /**
-   * @param type Does not affect `herumi` implementation, always de-serializes to `jacobian`
    * @param validate With `herumi` implementation signature validation is always on regardless of this flag.
    */
-  static fromBytes(bytes: Uint8Array, _type?: CoordType, _validate = true): Signature {
+  static fromBytes(bytes: Uint8Array, _validate = true): Signature {
     const context = getContext();
     const signature = new context.Signature();
     if (!isZeroUint8Array(bytes)) {
@@ -41,14 +40,14 @@ export class Signature implements ISignature {
     return this.fromBytes(hexToBytes(hex));
   }
 
-  static aggregate(signatures: SignatureArg[]): Signature {
+  static aggregate(signatures: Signature[]): Signature {
     if (signatures.length === 0) {
       throw new EmptyAggregateError();
     }
 
     const context = getContext();
     const agg = new context.Signature();
-    agg.aggregate(signatures.map(Signature.convertToSignatureType));
+    agg.aggregate(signatures.map((sig) => sig["value"]));
     return new Signature(agg);
   }
 
@@ -57,35 +56,26 @@ export class Signature implements ISignature {
 
     const context = getContext();
     return context.multiVerify(
-      sets.map((s) => PublicKey.convertToPublicKeyType(s.publicKey)),
-      sets.map((s) => Signature.convertToSignatureType(s.signature)),
+      sets.map((s) => (s.publicKey as PublicKey)["value"]),
+      sets.map((s) => (s.signature as Signature)["value"]),
       sets.map((s) => s.message)
     );
   }
 
-  static convertToSignatureType(signature: SignatureArg): SignatureType {
-    let sig: Signature;
-    if (signature instanceof Uint8Array) {
-      validateBytes(signature, "signature");
-      sig = Signature.fromBytes(signature);
-    } else {
-      // need to cast to herumi sig instead of ISignature
-      sig = signature as Signature;
-    }
-    return sig.value;
-  }
-
-  verify(publicKey: PublicKeyArg, message: Uint8Array): boolean {
+  verify(publicKey: PublicKey, message: Uint8Array): boolean {
     validateBytes(message, "message");
-    return PublicKey.convertToPublicKeyType(publicKey).verify(this.value, message);
+    return publicKey["value"].verify(this.value, message);
   }
 
-  verifyAggregate(publicKeys: PublicKeyArg[], message: Uint8Array): boolean {
+  verifyAggregate(publicKeys: PublicKey[], message: Uint8Array): boolean {
     validateBytes(message, "message");
-    return this.value.fastAggregateVerify(publicKeys.map(PublicKey.convertToPublicKeyType), message);
+    return this.value.fastAggregateVerify(
+      publicKeys.map((pk) => pk["value"]),
+      message
+    );
   }
 
-  verifyMultiple(publicKeys: PublicKeyArg[], messages: Uint8Array[]): boolean {
+  verifyMultiple(publicKeys: PublicKey[], messages: Uint8Array[]): boolean {
     // TODO: (@matthewkeil) this was in the verifyMultiple free function but was moved here for herumi. blst-native
     //       does this check but throws error instead of returning false.  Need to double check spec on which is
     //       correct handling
@@ -96,20 +86,20 @@ export class Signature implements ISignature {
     validateBytes(messages, "message");
 
     return this.value.aggregateVerifyNoCheck(
-      publicKeys.map(PublicKey.convertToPublicKeyType),
+      publicKeys.map((pk) => pk["value"]),
       concatUint8Arrays(messages)
     );
   }
 
-  toBytes(format?: PointFormat): Uint8Array {
-    if (format === PointFormat.uncompressed) {
+  toBytes(compress = true): Uint8Array {
+    if (!compress) {
       return this.value.serializeUncompressed();
     } else {
       return this.value.serialize();
     }
   }
 
-  toHex(format?: PointFormat): string {
-    return bytesToHex(this.toBytes(format));
+  toHex(compress = true): string {
+    return bytesToHex(this.toBytes(compress));
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,7 @@ export declare class SecretKey {
   private constructor(...t: any);
   static fromBytes(bytes: Uint8Array): SecretKey;
   static fromHex(hex: string): SecretKey;
-  static fromKeygen(entropy: Uint8Array): SecretKey;
+  static fromKeygen(entropy?: Uint8Array): SecretKey;
   sign(message: Uint8Array): Signature;
   toPublicKey(): PublicKey;
   toBytes(): Uint8Array;

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,31 +64,6 @@ export interface IBls {
    * signatures. Use the `Signature.verifyMultipleSignatures` if throwing is desired.
    */
   verifyMultipleSignatures(sets: SignatureSet[]): boolean;
-  /**
-   * Will asynchronously verify a signature. This function catches invalid input and return false for
-   * bad keys or signatures. Use the `Signature.asyncVerify` method if throwing is desired.
-   */
-  asyncVerify(publicKey: PublicKeyArg, message: Uint8Array, signature: SignatureArg): Promise<boolean>;
-  /**
-   * Will asynchronously verify a signature over a message by multiple aggregated keys. This function
-   * catches invalid input and return false for bad keys or signatures. Use the
-   * `Signature.asyncVerifyAggregate` if throwing is desired.
-   */
-  asyncVerifyAggregate(publicKeys: PublicKeyArg[], message: Uint8Array, signature: SignatureArg): Promise<boolean>;
-  /**
-   * Will asynchronously verify an aggregated signature over a number of messages each signed by a
-   * different key. This function catches invalid input and return false for bad keys or signatures.
-   * Use the `Signature.asyncVerifyAggregate` if throwing is desired.
-   *
-   * Note: the number of keys and messages must match.
-   */
-  asyncVerifyMultiple(publicKeys: PublicKeyArg[], messages: Uint8Array[], signature: SignatureArg): Promise<boolean>;
-  /**
-   * Will asynchronously verify a group of SignatureSets where each contains a signature signed for
-   * a message by a public key. This function catches invalid input and return false for bad keys or
-   * signatures. Use the Signature.asyncVerifyMultipleSignatures if throwing is desired.
-   */
-  asyncVerifyMultipleSignatures(sets: SignatureSet[]): Promise<boolean>;
 }
 
 export declare class SecretKey {
@@ -113,7 +88,6 @@ export declare class PublicKey {
   /** @param format Defaults to `PointFormat.compressed` */
   toBytes(format?: PointFormat): Uint8Array;
   toHex(format?: PointFormat): string;
-  multiplyBy(bytes: Uint8Array): PublicKey;
 }
 
 export declare class Signature {
@@ -130,12 +104,6 @@ export declare class Signature {
    * invalid input. Use the free function `verifyMultipleSignatures` if throwing is not desired.
    */
   static verifyMultipleSignatures(sets: SignatureSet[]): boolean;
-  /**
-   * Will asynchronously verify a group of SignatureSets where each contains a signature signed for
-   * a message by a public key. This version of the function will potentially throw errors for
-   * invalid input. Use the free function `verifyMultipleSignatures` if throwing is not desired.
-   */
-  static asyncVerifyMultipleSignatures(sets: SignatureSet[]): Promise<boolean>;
   /**
    * Will synchronously verify a signature. This version of the function will potentially throw
    * errors for invalid input. Use the free function `verify` if throwing is not desired.
@@ -156,28 +124,8 @@ export declare class Signature {
    */
   verifyMultiple(publicKeys: PublicKeyArg[], messages: Uint8Array[]): boolean;
   /**
-   * Will asynchronously verify a signature.  This version of the function will potentially throw
-   * errors for invalid input. Use the free function `asyncVerify` if throwing is not desired.
-   */
-  asyncVerify(publicKey: PublicKeyArg, message: Uint8Array): Promise<boolean>;
-  /**
-   * Will asynchronously verify a signature over a message by multiple aggregated keys.  This
-   * version of the function will potentially throw errors for invalid input. Use the free function
-   * `asyncVerifyAggregate` if throwing is not desired.
-   */
-  asyncVerifyAggregate(publicKeys: PublicKeyArg[], message: Uint8Array): Promise<boolean>;
-  /**
-   * Will asynchronously verify an aggregated signature over a number of messages each signed by a
-   * different key. This version of the function will potentially throw errors for invalid input.
-   * Use the free function `asyncVerifyMultiple` if throwing is not desired.
-   *
-   * Note: the number of keys and messages must match.
-   */
-  asyncVerifyMultiple(publicKeys: PublicKeyArg[], messages: Uint8Array[]): Promise<boolean>;
-  /**
    * @default format - `PointFormat.compressed`
    */
   toBytes(format?: PointFormat): Uint8Array;
   toHex(format?: PointFormat): string;
-  multiplyBy(bytes: Uint8Array): Signature;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,8 @@ export type Implementation = "herumi" | "blst-native";
 
 export interface SerializedSignatureSet {
   message: Uint8Array;
-  publicKey: PublicKey;
-  signature: Signature;
+  publicKey: Uint8Array;
+  signature: Uint8Array;
 }
 
 export interface SignatureSet {
@@ -46,13 +46,15 @@ export interface IBls {
    * a message by a public key. This function catches invalid input and return false for bad keys or
    * signatures. Use the `Signature.verifyMultipleSignatures` if throwing is desired.
    */
-  verifyMultipleSignatures(sets: SignatureSet[]): boolean;
+  verifyMultipleSignatures(sets: SerializedSignatureSet[]): boolean;
 }
 
 export declare class SecretKey {
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  private constructor(...t: any);
   static fromBytes(bytes: Uint8Array): SecretKey;
   static fromHex(hex: string): SecretKey;
-  static fromKeygen(entropy?: Uint8Array): SecretKey;
+  static fromKeygen(entropy: Uint8Array): SecretKey;
   sign(message: Uint8Array): Signature;
   toPublicKey(): PublicKey;
   toBytes(): Uint8Array;
@@ -60,16 +62,20 @@ export declare class SecretKey {
 }
 
 export declare class PublicKey {
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  private constructor(...t: any);
   static fromBytes(bytes: Uint8Array, validate?: boolean): PublicKey;
   static fromHex(hex: string, validate?: boolean): PublicKey;
   static aggregate(publicKeys: PublicKey[]): PublicKey;
-  /** @param compressed Defaults to `true` */
-  toBytes(compressed?: boolean): Uint8Array;
-  /** @param compressed Defaults to `true` */
-  toHex(compressed?: boolean): string;
+  /** @param compress Defaults to `true` */
+  toBytes(compress?: boolean): Uint8Array;
+  /** @param compress Defaults to `true` */
+  toHex(compress?: boolean): string;
 }
 
 export declare class Signature {
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  private constructor(...t: any);
   /**  @param validate When using `herumi` implementation, signature validation is always on regardless of this flag. */
   static fromBytes(bytes: Uint8Array, validate?: boolean): Signature;
   /**  @param validate When using `herumi` implementation, signature validation is always on regardless of this flag. */
@@ -100,8 +106,8 @@ export declare class Signature {
    * Note: the number of keys and messages must match.
    */
   verifyMultiple(publicKeys: PublicKey[], messages: Uint8Array[]): boolean;
-  /** @param compressed Defaults to `true` */
-  toBytes(compressed?: boolean): Uint8Array;
-  /** @param compressed Defaults to `true` */
-  toHex(compressed?: boolean): string;
+  /** @param compress Defaults to `true` */
+  toBytes(compress?: boolean): Uint8Array;
+  /** @param compress Defaults to `true` */
+  toHex(compress?: boolean): string;
 }

--- a/test/spec/fast_aggregate_verify.test.ts
+++ b/test/spec/fast_aggregate_verify.test.ts
@@ -1,7 +1,6 @@
 import path from "path";
 import {describeDirectorySpecTest, InputType} from "@lodestar/spec-test-util";
 import {hexToBytes} from "../../src/helpers/index.js";
-import {CoordType} from "../../src/types.js";
 import {SPEC_TESTS_DIR} from "../params.js";
 import {describeForAllImplementations} from "../switch.js";
 
@@ -25,7 +24,7 @@ describeForAllImplementations((bls) => {
       const {pubkeys, message, signature} = testCase.data.input;
       try {
         return bls.Signature.fromBytes(hexToBytes(signature)).verifyAggregate(
-          pubkeys.map((hex) => bls.PublicKey.fromBytes(hexToBytes(hex), CoordType.jacobian, true)),
+          pubkeys.map((hex) => bls.PublicKey.fromBytes(hexToBytes(hex), true)),
           hexToBytes(message)
         );
       } catch (e) {

--- a/test/unit/index-named-exports.test.ts
+++ b/test/unit/index-named-exports.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 import type {SecretKey, PublicKey, Signature, IBls} from "../../src/types.js";
-import { randomMessage } from "../util.js";
+import {randomMessage} from "../util.js";
 
 describe("types named exports", async () => {
   let bls: IBls;

--- a/test/unit/index-named-exports.test.ts
+++ b/test/unit/index-named-exports.test.ts
@@ -1,5 +1,6 @@
 import {expect} from "chai";
 import type {SecretKey, PublicKey, Signature, IBls} from "../../src/types.js";
+import { randomMessage } from "../util.js";
 
 describe("types named exports", async () => {
   let bls: IBls;
@@ -16,7 +17,7 @@ describe("types named exports", async () => {
       return sig.verify(pk, msg);
     }
 
-    const sk = bls.SecretKey.fromKeygen();
+    const sk = bls.SecretKey.fromKeygen(randomMessage());
     const msg = new Uint8Array(32);
     const sig = sk.sign(msg);
     const pk = sk.toPublicKey();
@@ -24,7 +25,7 @@ describe("types named exports", async () => {
   });
 
   it("Make sure exported classes are compatible with interface", () => {
-    const sk: SecretKey = bls.SecretKey.fromKeygen();
+    const sk: SecretKey = bls.SecretKey.fromKeygen(randomMessage());
     const pk: PublicKey = sk.toPublicKey();
     const sig: Signature = sk.sign(new Uint8Array(32));
     pk;

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -189,7 +189,7 @@ export function runIndexTests(bls: IBls): void {
 
     it("should fail verify empty message", () => {
       const n = 4;
-      const sets = getN(n, (i) => {
+      const sets = getN(n, () => {
         const sk = bls.SecretKey.fromKeygen();
         const publicKey = sk.toPublicKey();
         const message = randomMessage();

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -8,7 +8,7 @@ import {maliciousVerifyMultipleSignaturesData} from "../data/malicious-signature
 export function runIndexTests(bls: IBls): void {
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   function getRandomData() {
-    const sk = bls.SecretKey.fromKeygen(randomMessage());
+    const sk = bls.SecretKey.fromKeygen();
     const pk = sk.toPublicKey();
     const msg = randomMessage();
     const sig = sk.sign(msg);
@@ -74,7 +74,7 @@ export function runIndexTests(bls: IBls): void {
 
   describe("verify multiple", () => {
     it("should verify aggregated signatures", () => {
-      const sks = getN(4, () => bls.SecretKey.fromKeygen(randomMessage()));
+      const sks = getN(4, () => bls.SecretKey.fromKeygen());
       const msgs = getN(2, () => randomMessage());
       const pks = sks.map((sk) => sk.toPublicKey());
 
@@ -94,7 +94,7 @@ export function runIndexTests(bls: IBls): void {
     it("should verify aggregated signatures - same message", () => {
       const n = 4;
       const msg = randomMessage();
-      const sks = getN(n, () => bls.SecretKey.fromKeygen(randomMessage()));
+      const sks = getN(n, () => bls.SecretKey.fromKeygen());
       const pks = sks.map((sk) => sk.toPublicKey());
       const sigs = sks.map((sk) => sk.sign(msg));
 
@@ -118,7 +118,7 @@ export function runIndexTests(bls: IBls): void {
     });
 
     it("should fail verify empty message", () => {
-      const sks = getN(2, () => bls.SecretKey.fromKeygen(randomMessage()));
+      const sks = getN(2, () => bls.SecretKey.fromKeygen());
       const msgs = getN(2, () => randomMessage());
       const pks = sks.map((sk) => sk.toPublicKey());
       const sigs = [sks[0].sign(msgs[0]), sks[1].sign(msgs[1])];
@@ -134,7 +134,7 @@ export function runIndexTests(bls: IBls): void {
     it("Should verify multiple signatures", () => {
       const n = 4;
       const sets = getN(n, () => {
-        const sk = bls.SecretKey.fromKeygen(randomMessage());
+        const sk = bls.SecretKey.fromKeygen();
         const publicKey = sk.toPublicKey();
         const message = randomMessage();
         const signature = sk.sign(message);
@@ -190,7 +190,7 @@ export function runIndexTests(bls: IBls): void {
     it("should fail verify empty message", () => {
       const n = 4;
       const sets = getN(n, (i) => {
-        const sk = bls.SecretKey.fromKeygen(Buffer.alloc(32, i));
+        const sk = bls.SecretKey.fromKeygen();
         const publicKey = sk.toPublicKey();
         const message = randomMessage();
         const signature = sk.sign(message);

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 import {Buffer} from "buffer";
-import {IBls, PointFormat} from "../../src/types.js";
+import {IBls} from "../../src/types.js";
 import {getN, randomMessage} from "../util.js";
 import {hexToBytes} from "../../src/helpers/index.js";
 import {maliciousVerifyMultipleSignaturesData} from "../data/malicious-signature-test-data.js";
@@ -8,7 +8,7 @@ import {maliciousVerifyMultipleSignaturesData} from "../data/malicious-signature
 export function runIndexTests(bls: IBls): void {
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   function getRandomData() {
-    const sk = bls.SecretKey.fromKeygen();
+    const sk = bls.SecretKey.fromKeygen(randomMessage());
     const pk = sk.toPublicKey();
     const msg = randomMessage();
     const sig = sk.sign(msg);
@@ -24,7 +24,7 @@ export function runIndexTests(bls: IBls): void {
       );
       let sig;
       try {
-        sig = bls.Signature.fromBytes(POINT_NOT_IN_G2, undefined, true);
+        sig = bls.Signature.fromBytes(POINT_NOT_IN_G2, true);
       } catch {
         /* eslint-disable no-empty */
       }
@@ -74,7 +74,7 @@ export function runIndexTests(bls: IBls): void {
 
   describe("verify multiple", () => {
     it("should verify aggregated signatures", () => {
-      const sks = getN(4, () => bls.SecretKey.fromKeygen());
+      const sks = getN(4, () => bls.SecretKey.fromKeygen(randomMessage()));
       const msgs = getN(2, () => randomMessage());
       const pks = sks.map((sk) => sk.toPublicKey());
 
@@ -94,7 +94,7 @@ export function runIndexTests(bls: IBls): void {
     it("should verify aggregated signatures - same message", () => {
       const n = 4;
       const msg = randomMessage();
-      const sks = getN(n, () => bls.SecretKey.fromKeygen());
+      const sks = getN(n, () => bls.SecretKey.fromKeygen(randomMessage()));
       const pks = sks.map((sk) => sk.toPublicKey());
       const sigs = sks.map((sk) => sk.sign(msg));
 
@@ -118,7 +118,7 @@ export function runIndexTests(bls: IBls): void {
     });
 
     it("should fail verify empty message", () => {
-      const sks = getN(2, () => bls.SecretKey.fromKeygen());
+      const sks = getN(2, () => bls.SecretKey.fromKeygen(randomMessage()));
       const msgs = getN(2, () => randomMessage());
       const pks = sks.map((sk) => sk.toPublicKey());
       const sigs = [sks[0].sign(msgs[0]), sks[1].sign(msgs[1])];
@@ -134,7 +134,7 @@ export function runIndexTests(bls: IBls): void {
     it("Should verify multiple signatures", () => {
       const n = 4;
       const sets = getN(n, () => {
-        const sk = bls.SecretKey.fromKeygen();
+        const sk = bls.SecretKey.fromKeygen(randomMessage());
         const publicKey = sk.toPublicKey();
         const message = randomMessage();
         const signature = sk.sign(message);
@@ -189,8 +189,8 @@ export function runIndexTests(bls: IBls): void {
 
     it("should fail verify empty message", () => {
       const n = 4;
-      const sets = getN(n, () => {
-        const sk = bls.SecretKey.fromKeygen();
+      const sets = getN(n, (i) => {
+        const sk = bls.SecretKey.fromKeygen(Buffer.alloc(32, i));
         const publicKey = sk.toPublicKey();
         const message = randomMessage();
         const signature = sk.sign(message);
@@ -215,13 +215,13 @@ export function runIndexTests(bls: IBls): void {
 
     it("Should serialize comp pubkey", () => {
       const sk = bls.SecretKey.fromBytes(hexToBytes(skHex));
-      const pkHexComp = sk.toPublicKey().toHex(PointFormat.compressed);
+      const pkHexComp = sk.toPublicKey().toHex();
       expect(pkHexComp).to.equal(pkHexCompExpected, "Wrong pkHexComp");
     });
 
     it("Should serialize uncomp pubkey", () => {
       const sk = bls.SecretKey.fromBytes(hexToBytes(skHex));
-      const pkHexUncomp = sk.toPublicKey().toHex(PointFormat.uncompressed);
+      const pkHexUncomp = sk.toPublicKey().toHex(false);
       expect(pkHexUncomp).to.equal(pkHexUncompExpected, "Wrong pkHexUncomp");
     });
 

--- a/test/unit/multithread/naive/index.ts
+++ b/test/unit/multithread/naive/index.ts
@@ -36,9 +36,7 @@ export class BlsMultiThreadNaive {
   }
 
   async verify(pk: PublicKey, msg: Uint8Array, sig: Signature): Promise<boolean> {
-    return this.pool.queue((worker) =>
-      worker.verify(this.impl, pk.toBytes(), msg, sig.toBytes())
-    );
+    return this.pool.queue((worker) => worker.verify(this.impl, pk.toBytes(), msg, sig.toBytes()));
   }
 
   async verifyMultipleAggregateSignatures(

--- a/test/unit/multithread/naive/naive.test.ts
+++ b/test/unit/multithread/naive/naive.test.ts
@@ -21,7 +21,7 @@ export function runMultithreadTests(bls: IBls): void {
 
     describe("1 msg, 1 pk", function () {
       const msg = Buffer.from("sample-msg");
-      const sk = bls.SecretKey.fromKeygen(Buffer.alloc(32, 1));
+      const sk = bls.SecretKey.fromKeygen();
       const pk = sk.toPublicKey();
       const sig = sk.sign(msg);
 
@@ -41,7 +41,7 @@ export function runMultithreadTests(bls: IBls): void {
       const sets: {publicKey: PublicKey; message: Uint8Array; signature: Signature}[] = [];
       for (let i = 0; i < n; i++) {
         const message = Buffer.alloc(32, i);
-        const sk = bls.SecretKey.fromKeygen(Buffer.alloc(32, i));
+        const sk = bls.SecretKey.fromKeygen();
         sets.push({message, publicKey: sk.toPublicKey(), signature: sk.sign(message)});
       }
 

--- a/test/unit/multithread/naive/worker.ts
+++ b/test/unit/multithread/naive/worker.ts
@@ -1,5 +1,5 @@
 import {expose} from "@chainsafe/threads/worker";
-import {CoordType, Implementation} from "../../../../src/types.js";
+import {Implementation} from "../../../../src/types.js";
 import bls, {init} from "../../../../src/switchable.js";
 
 export type WorkerApi = typeof workerApi;
@@ -7,8 +7,8 @@ export type WorkerApi = typeof workerApi;
 const workerApi = {
   async verify(impl: Implementation, publicKey: Uint8Array, message: Uint8Array, signature: Uint8Array) {
     await init(impl);
-    const pk = bls.PublicKey.fromBytes(publicKey, CoordType.affine);
-    const sig = bls.Signature.fromBytes(signature, CoordType.affine, true);
+    const pk = bls.PublicKey.fromBytes(publicKey);
+    const sig = bls.Signature.fromBytes(signature);
     return sig.verify(pk, message);
   },
   async verifyMultipleAggregateSignatures(
@@ -18,9 +18,9 @@ const workerApi = {
     await init(impl);
     return bls.Signature.verifyMultipleSignatures(
       sets.map((s) => ({
-        publicKey: bls.PublicKey.fromBytes(s.publicKey, CoordType.affine),
+        publicKey: bls.PublicKey.fromBytes(s.publicKey),
         message: s.message,
-        signature: bls.Signature.fromBytes(s.signature, CoordType.affine, true),
+        signature: bls.Signature.fromBytes(s.signature),
       }))
     );
   },

--- a/test/unit/publicKey.test.ts
+++ b/test/unit/publicKey.test.ts
@@ -15,7 +15,7 @@ export function runPublicKeyTests(bls: IBls): void {
     });
 
     it("from secret key", () => {
-      bls.SecretKey.fromKeygen(Buffer.alloc(32)).toPublicKey();
+      bls.SecretKey.fromKeygen().toPublicKey();
     });
   });
 }

--- a/test/unit/publicKey.test.ts
+++ b/test/unit/publicKey.test.ts
@@ -15,7 +15,7 @@ export function runPublicKeyTests(bls: IBls): void {
     });
 
     it("from secret key", () => {
-      bls.SecretKey.fromKeygen().toPublicKey();
+      bls.SecretKey.fromKeygen(Buffer.alloc(32)).toPublicKey();
     });
   });
 }

--- a/test/unit/secretKey.test.ts
+++ b/test/unit/secretKey.test.ts
@@ -4,8 +4,8 @@ import {IBls} from "../../src/types.js";
 export function runSecretKeyTests(bls: IBls): void {
   describe("SecretKey", () => {
     it("should generate fromKeygen secret key", () => {
-      const secretKey1 = bls.SecretKey.fromKeygen();
-      const secretKey2 = bls.SecretKey.fromKeygen();
+      const secretKey1 = bls.SecretKey.fromKeygen(Buffer.alloc(32, 1));
+      const secretKey2 = bls.SecretKey.fromKeygen(Buffer.alloc(32, 2));
       expect(secretKey1.toHex()).to.not.be.equal(secretKey2.toHex());
     });
 

--- a/test/unit/secretKey.test.ts
+++ b/test/unit/secretKey.test.ts
@@ -4,8 +4,8 @@ import {IBls} from "../../src/types.js";
 export function runSecretKeyTests(bls: IBls): void {
   describe("SecretKey", () => {
     it("should generate fromKeygen secret key", () => {
-      const secretKey1 = bls.SecretKey.fromKeygen(Buffer.alloc(32, 1));
-      const secretKey2 = bls.SecretKey.fromKeygen(Buffer.alloc(32, 2));
+      const secretKey1 = bls.SecretKey.fromKeygen();
+      const secretKey2 = bls.SecretKey.fromKeygen();
       expect(secretKey1.toHex()).to.not.be.equal(secretKey2.toHex());
     });
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -4,8 +4,8 @@ export function randomMessage(): Uint8Array {
   return randomBytes(32);
 }
 
-export function getN<T>(n: number, getter: () => T): T[] {
-  return Array.from({length: n}, () => getter());
+export function getN<T>(n: number, getter: (i: number) => T): T[] {
+  return Array.from({length: n}, (_, i) => getter(i));
 }
 
 export function range(n: number): number[] {

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -29,6 +29,9 @@ module.exports = {
       child_process: false,
     },
   },
+  externals: {
+    "@chainsafe/blst": {}
+  },
   experiments: {
     topLevelAwait: true,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,14 +227,41 @@
     "@noble/hashes" "^1.0.0"
     "@scure/bip39" "^1.0.0"
 
-"@chainsafe/blst@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-1.0.0.tgz#0939f5b38389ca8ae00fcc6b6555063113f611a7"
-  integrity sha512-WQDxFvcG+glmusXnWQ3W4g2tvHuTQEK0/cIZz37TskZJqOqAtOogZsK3cD3j+OoxbdCRT6l08QUCOtPMOLe/zA==
-  dependencies:
-    node-addon-api "^6.1.0"
-    node-gyp "^10.0.1"
-    ts-node "^10.9.2"
+"@chainsafe/blst-darwin-arm64@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst-darwin-arm64/-/blst-darwin-arm64-2.0.1.tgz#d96d6dd906a6c9c809d6f5b5539e031ccff63b25"
+  integrity sha512-ZmRLimvo+BoMcpalzuS3Pj0j6l2cSDU7qMBwjch49ljkrsr4/rls7COMW8MSyDyVUSfzg0agotAByYfs+Bg3ZQ==
+
+"@chainsafe/blst-darwin-x64@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst-darwin-x64/-/blst-darwin-x64-2.0.1.tgz#56018c5955337a5e2b754e941bdcda0a2c6f1a84"
+  integrity sha512-5DPtmKhia5/k0szjsrgxF7GCOE5pnSRcsLvtlChzkLY7KhfxnGt5XeNtCK6NoAAfcxzN8mZrwvvzDfsDmImTQg==
+
+"@chainsafe/blst-linux-arm64-gnu@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst-linux-arm64-gnu/-/blst-linux-arm64-gnu-2.0.1.tgz#23a66095eaf4c23a8c54ef7df27d9c80d45ebb32"
+  integrity sha512-REIW0uM9a97iasE+RX+M1yEmIywOF1ly9/xl7JTYYASXoDDQD2eL06k17N5kXE/382wU28fU/h6V2qmWcqiWAQ==
+
+"@chainsafe/blst-linux-x64-gnu@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst-linux-x64-gnu/-/blst-linux-x64-gnu-2.0.1.tgz#1769640e9b9140ee3e4142520c00d09c9ebc66e9"
+  integrity sha512-zH7GkMI+wWVKGp5MA+8A2EGx9fe5/jktz/KB2SrGhBu956IXh7qCV9mMCOzA4mmpxSuxjzD4auXpQc/D4uApLw==
+
+"@chainsafe/blst-win32-x64-msvc@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst-win32-x64-msvc/-/blst-win32-x64-msvc-2.0.1.tgz#dfebc2ea23875bc02ffac11d2d15bf6e644d59ed"
+  integrity sha512-RcOo1Sl1Ai5igp56l3I5kwWkesfbD14PBoUcoR61phvIHnhyZzOtVX6rhuCYwcl0IIgSDSWtNNMdSwX34GGmxA==
+
+"@chainsafe/blst@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-2.0.1.tgz#9e8ceb6766fcb231e4fa378eee6378275018a159"
+  integrity sha512-+sIlLzFb6htv1WH3XIF2WDN+qlstGpo8Zl5ibxzT6VsiBSswsH05AQMpd4uQfRO1uFKhEk9JDKi8bHvIDmN8Jg==
+  optionalDependencies:
+    "@chainsafe/blst-darwin-arm64" "2.0.1"
+    "@chainsafe/blst-darwin-x64" "2.0.1"
+    "@chainsafe/blst-linux-arm64-gnu" "2.0.1"
+    "@chainsafe/blst-linux-x64-gnu" "2.0.1"
+    "@chainsafe/blst-win32-x64-msvc" "2.0.1"
 
 "@chainsafe/eslint-plugin-node@^11.2.3":
   version "11.2.3"
@@ -311,18 +338,6 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
-
-"@isaacs/cliui@^8.0.2":
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
-  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
-  dependencies:
-    string-width "^5.1.2"
-    string-width-cjs "npm:string-width@^4.2.0"
-    strip-ansi "^7.0.1"
-    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
-    wrap-ansi "^8.1.0"
-    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.0.0"
@@ -476,30 +491,12 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@npmcli/agent@^2.0.0":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@npmcli/agent/-/agent-2.2.2.tgz#967604918e62f620a648c7975461c9c9e74fc5d5"
-  integrity sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==
-  dependencies:
-    agent-base "^7.1.0"
-    http-proxy-agent "^7.0.0"
-    https-proxy-agent "^7.0.1"
-    lru-cache "^10.0.1"
-    socks-proxy-agent "^8.0.3"
-
 "@npmcli/fs@^2.1.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-2.1.2.tgz#a9e2541a4a2fec2e69c29b35e6060973da79b865"
   integrity sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==
   dependencies:
     "@gar/promisify" "^1.1.3"
-    semver "^7.3.5"
-
-"@npmcli/fs@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-3.1.0.tgz#233d43a25a91d68c3a863ba0da6a3f00924a173e"
-  integrity sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==
-  dependencies:
     semver "^7.3.5"
 
 "@npmcli/move-file@^2.0.0":
@@ -509,11 +506,6 @@
   dependencies:
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
-
-"@pkgjs/parseargs@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
-  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
 "@scure/base@~1.0.0":
   version "1.0.0"
@@ -875,11 +867,6 @@ abbrev@1, abbrev@^1.0.0:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-abbrev@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz#cf59829b8b4f03f89dda2771cb7f3653828c89bf"
-  integrity sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==
-
 accepts@~1.3.4:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -924,13 +911,6 @@ agent-base@6, agent-base@^6.0.2:
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
-
-agent-base@^7.0.2, agent-base@^7.1.0, agent-base@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.1.tgz#bdbded7dfb096b751a2a087eeeb9664725b2e317"
-  integrity sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==
-  dependencies:
-    debug "^4.3.4"
 
 agentkeepalive@^4.2.1:
   version "4.5.0"
@@ -982,11 +962,6 @@ ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-regex@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
-  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
-
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -1008,11 +983,6 @@ ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
-
-ansi-styles@^6.1.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
-  integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
 any-signal@3.0.1:
   version "3.0.1"
@@ -1270,24 +1240,6 @@ cacache@^16.1.0:
     ssri "^9.0.0"
     tar "^6.1.11"
     unique-filename "^2.0.0"
-
-cacache@^18.0.0:
-  version "18.0.2"
-  resolved "https://registry.yarnpkg.com/cacache/-/cacache-18.0.2.tgz#fd527ea0f03a603be5c0da5805635f8eef00c60c"
-  integrity sha512-r3NU8h/P+4lVUHfeRw1dtgQYar3DZMm4/cm2bZgOvrFC/su7budSOeqh52VJIC4U4iG1WWwV6vRW0znqBvxNuw==
-  dependencies:
-    "@npmcli/fs" "^3.1.0"
-    fs-minipass "^3.0.0"
-    glob "^10.2.2"
-    lru-cache "^10.0.1"
-    minipass "^7.0.3"
-    minipass-collect "^2.0.1"
-    minipass-flush "^1.0.5"
-    minipass-pipeline "^1.2.4"
-    p-map "^4.0.0"
-    ssri "^10.0.0"
-    tar "^6.1.11"
-    unique-filename "^3.0.0"
 
 caching-transform@^4.0.0:
   version "4.0.0"
@@ -1744,11 +1696,6 @@ dom-serialize@^2.2.1:
     extend "^3.0.0"
     void-elements "^2.0.0"
 
-eastasianwidth@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
-  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
-
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -1763,11 +1710,6 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
-emoji-regex@^9.2.2:
-  version "9.2.2"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
-  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
 emojis-list@^3.0.0:
   version "3.0.0"
@@ -2118,11 +2060,6 @@ execa@^5.0.0:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
-exponential-backoff@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
-  integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
-
 extend@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
@@ -2266,14 +2203,6 @@ foreground-child@^2.0.0:
     cross-spawn "^7.0.0"
     signal-exit "^3.0.2"
 
-foreground-child@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.1.1.tgz#1d173e776d75d2772fed08efe4a0de1ea1b12d0d"
-  integrity sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==
-  dependencies:
-    cross-spawn "^7.0.0"
-    signal-exit "^4.0.1"
-
 form-data@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
@@ -2303,13 +2232,6 @@ fs-minipass@^2.0.0, fs-minipass@^2.1.0:
   integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
   dependencies:
     minipass "^3.0.0"
-
-fs-minipass@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-3.0.3.tgz#79a85981c4dc120065e96f62086bf6f9dc26cc54"
-  integrity sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==
-  dependencies:
-    minipass "^7.0.3"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2412,17 +2334,6 @@ glob@7.2.0, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-glob@^10.2.2, glob@^10.3.10:
-  version "10.3.12"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-10.3.12.tgz#3a65c363c2e9998d220338e88a5f6ac97302960b"
-  integrity sha512-TCNv8vJ+xz4QiqTpfOJA7HvYv+tNIRHKfUWw/q+v2jdgN4ebz+KY9tGx5J4rHP0o84mNP+ApH66HRX8us3Khqg==
-  dependencies:
-    foreground-child "^3.1.0"
-    jackspeak "^2.3.6"
-    minimatch "^9.0.1"
-    minipass "^7.0.4"
-    path-scurry "^1.10.2"
 
 glob@^8.0.1:
   version "8.1.0"
@@ -2529,7 +2440,7 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.0.tgz#71e87f931de3fe09e56661ab9a29aadec707b491"
   integrity sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==
 
-http-cache-semantics@^4.1.0, http-cache-semantics@^4.1.1:
+http-cache-semantics@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
   integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
@@ -2554,14 +2465,6 @@ http-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-http-proxy-agent@^7.0.0:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
-  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
-  dependencies:
-    agent-base "^7.1.0"
-    debug "^4.3.4"
-
 http-proxy@^1.18.1:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
@@ -2577,14 +2480,6 @@ https-proxy-agent@^5.0.0:
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
   dependencies:
     agent-base "6"
-    debug "4"
-
-https-proxy-agent@^7.0.1:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz#8e97b841a029ad8ddc8731f26595bad868cb4168"
-  integrity sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==
-  dependencies:
-    agent-base "^7.0.2"
     debug "4"
 
 human-signals@^2.1.0:
@@ -2684,14 +2579,6 @@ interpret@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
-
-ip-address@^9.0.5:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-9.0.5.tgz#117a960819b08780c3bd1f14ef3c1cc1d3f3ea5a"
-  integrity sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==
-  dependencies:
-    jsbn "1.1.0"
-    sprintf-js "^1.1.3"
 
 ip@^1.1.5:
   version "1.1.9"
@@ -2832,11 +2719,6 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-isexe@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-3.1.1.tgz#4a407e2bd78ddfb14bea0c27c6f7072dde775f0d"
-  integrity sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==
-
 isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
@@ -2906,15 +2788,6 @@ istanbul-reports@^3.0.0:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-jackspeak@^2.3.6:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-2.3.6.tgz#647ecc472238aee4b06ac0e461acc21a8c505ca8"
-  integrity sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==
-  dependencies:
-    "@isaacs/cliui" "^8.0.2"
-  optionalDependencies:
-    "@pkgjs/parseargs" "^0.11.0"
-
 jest-worker@^27.4.5:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.5.1.tgz#8d146f0900e8973b106b6f73cc1e9a8cb86f8db0"
@@ -2943,11 +2816,6 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-jsbn@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
-  integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -3172,11 +3040,6 @@ loupe@^2.3.6:
   dependencies:
     get-func-name "^2.0.1"
 
-lru-cache@^10.0.1, lru-cache@^10.2.0, "lru-cache@^9.1.1 || ^10.0.0":
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.0.tgz#0bd445ca57363465900f4d1f9bd8db343a4d95c3"
-  integrity sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==
-
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -3188,6 +3051,11 @@ lru-cache@^7.7.1:
   version "7.18.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
+
+"lru-cache@^9.1.1 || ^10.0.0":
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.0.tgz#0bd445ca57363465900f4d1f9bd8db343a4d95c3"
+  integrity sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==
 
 make-dir@^3.0.0:
   version "3.0.2"
@@ -3229,23 +3097,6 @@ make-fetch-happen@^10.0.3:
     promise-retry "^2.0.1"
     socks-proxy-agent "^7.0.0"
     ssri "^9.0.0"
-
-make-fetch-happen@^13.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-13.0.0.tgz#705d6f6cbd7faecb8eac2432f551e49475bfedf0"
-  integrity sha512-7ThobcL8brtGo9CavByQrQi+23aIfgYU++wg4B87AIS8Rb2ZBt/MEaDqzA00Xwv/jUjAjYkLHjVolYuTLKda2A==
-  dependencies:
-    "@npmcli/agent" "^2.0.0"
-    cacache "^18.0.0"
-    http-cache-semantics "^4.1.1"
-    is-lambda "^1.0.1"
-    minipass "^7.0.2"
-    minipass-fetch "^3.0.0"
-    minipass-flush "^1.0.5"
-    minipass-pipeline "^1.2.4"
-    negotiator "^0.6.3"
-    promise-retry "^2.0.1"
-    ssri "^10.0.0"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -3335,13 +3186,6 @@ minimatch@^8.0.2:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^9.0.1:
-  version "9.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.4.tgz#8e49c731d1749cbec05050ee5145147b32496a51"
-  integrity sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 minimist@^1.2.3, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
@@ -3354,30 +3198,12 @@ minipass-collect@^1.0.2:
   dependencies:
     minipass "^3.0.0"
 
-minipass-collect@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/minipass-collect/-/minipass-collect-2.0.1.tgz#1621bc77e12258a12c60d34e2276ec5c20680863"
-  integrity sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==
-  dependencies:
-    minipass "^7.0.3"
-
 minipass-fetch@^2.0.3:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-2.1.2.tgz#95560b50c472d81a3bc76f20ede80eaed76d8add"
   integrity sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==
   dependencies:
     minipass "^3.1.6"
-    minipass-sized "^1.0.3"
-    minizlib "^2.1.2"
-  optionalDependencies:
-    encoding "^0.1.13"
-
-minipass-fetch@^3.0.0:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-3.0.4.tgz#4d4d9b9f34053af6c6e597a64be8e66e42bf45b7"
-  integrity sha512-jHAqnA728uUpIaFm7NWsCnqKT6UqZz7GcI/bDpPATuwYyKwJwW0remxSCxUlKiEty+eopHGa3oc8WxgQ1FFJqg==
-  dependencies:
-    minipass "^7.0.3"
     minipass-sized "^1.0.3"
     minizlib "^2.1.2"
   optionalDependencies:
@@ -3428,7 +3254,7 @@ minipass@^5.0.0:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
   integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.2, minipass@^7.0.3, minipass@^7.0.4:
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.0.4.tgz#dbce03740f50a4786ba994c1fb908844d27b038c"
   integrity sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==
@@ -3561,11 +3387,6 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-node-addon-api@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-6.1.0.tgz#ac8470034e58e67d0c6f1204a18ae6995d9c0d76"
-  integrity sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==
-
 node-fetch@^2.6.5:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
@@ -3588,22 +3409,6 @@ node-gyp@9.3.1:
     semver "^7.3.5"
     tar "^6.1.2"
     which "^2.0.2"
-
-node-gyp@^10.0.1:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-10.1.0.tgz#75e6f223f2acb4026866c26a2ead6aab75a8ca7e"
-  integrity sha512-B4J5M1cABxPc5PwfjhbV5hoy2DP9p8lFXASnEN6hugXOa61416tnTZ29x9sSwAd0o99XNIcpvDDy1swAExsVKA==
-  dependencies:
-    env-paths "^2.2.0"
-    exponential-backoff "^3.1.1"
-    glob "^10.3.10"
-    graceful-fs "^4.2.6"
-    make-fetch-happen "^13.0.0"
-    nopt "^7.0.0"
-    proc-log "^3.0.0"
-    semver "^7.3.5"
-    tar "^6.1.2"
-    which "^4.0.0"
 
 node-preload@^0.2.0:
   version "0.2.1"
@@ -3630,13 +3435,6 @@ nopt@^6.0.0:
   integrity sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==
   dependencies:
     abbrev "^1.0.0"
-
-nopt@^7.0.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-7.2.0.tgz#067378c68116f602f552876194fd11f1292503d7"
-  integrity sha512-CVDtwCdhYIvnAzFoJ6NJ6dX3oga9/HyciQDnG1vQDjSLMeKLJ4A93ZqYKDrgYSr1FBY5/hMYC+2VCi24pgpkGA==
-  dependencies:
-    abbrev "^2.0.0"
 
 normalize-package-data@^2.3.2:
   version "2.5.0"
@@ -3927,14 +3725,6 @@ path-parse@^1.0.6, path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-scurry@^1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.10.2.tgz#8f6357eb1239d5fa1da8b9f70e9c080675458ba7"
-  integrity sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==
-  dependencies:
-    lru-cache "^10.2.0"
-    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
-
 path-scurry@^1.6.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.10.1.tgz#9ba6bf5aa8500fe9fd67df4f0d9483b2b0bfc698"
@@ -4015,11 +3805,6 @@ prettier@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
   integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
-
-proc-log@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/proc-log/-/proc-log-3.0.0.tgz#fb05ef83ccd64fd7b20bbe9c8c1070fc08338dd8"
-  integrity sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==
 
 process-on-spawn@^1.0.0:
   version "1.0.0"
@@ -4365,11 +4150,6 @@ signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
-signal-exit@^4.0.1:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
-  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
-
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -4429,29 +4209,12 @@ socks-proxy-agent@^7.0.0:
     debug "^4.3.3"
     socks "^2.6.2"
 
-socks-proxy-agent@^8.0.3:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz#6b2da3d77364fde6292e810b496cb70440b9b89d"
-  integrity sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==
-  dependencies:
-    agent-base "^7.1.1"
-    debug "^4.3.4"
-    socks "^2.7.1"
-
 socks@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.2.tgz#ec042d7960073d40d94268ff3bb727dc685f111a"
   integrity sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==
   dependencies:
     ip "^1.1.5"
-    smart-buffer "^4.2.0"
-
-socks@^2.7.1:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.8.3.tgz#1ebd0f09c52ba95a09750afe3f3f9f724a800cb5"
-  integrity sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==
-  dependencies:
-    ip-address "^9.0.5"
     smart-buffer "^4.2.0"
 
 source-map-support@~0.5.20:
@@ -4510,22 +4273,10 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
-sprintf-js@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a"
-  integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==
-
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
-
-ssri@^10.0.0:
-  version "10.0.5"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-10.0.5.tgz#e49efcd6e36385196cb515d3a2ad6c3f0265ef8c"
-  integrity sha512-bSf16tAFkGeRlUNDjXu8FzaMQt6g2HZJrun7mtMbIPOddxt3GLMSz5VWUWcqTJUPfLEaDIepGxv+bYQW49596A==
-  dependencies:
-    minipass "^7.0.3"
 
 ssri@^9.0.0:
   version "9.0.1"
@@ -4553,15 +4304,6 @@ streamroller@^3.0.8:
     debug "^4.3.4"
     fs-extra "^10.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
 "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -4579,15 +4321,6 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
-
-string-width@^5.0.1, string-width@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
-  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
-  dependencies:
-    eastasianwidth "^0.2.0"
-    emoji-regex "^9.2.2"
-    strip-ansi "^7.0.1"
 
 string.prototype.trimleft@^2.1.1:
   version "2.1.1"
@@ -4612,13 +4345,6 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
 strip-ansi@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
@@ -4632,13 +4358,6 @@ strip-ansi@^6.0.1:
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
-
-strip-ansi@^7.0.1:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.0.tgz#d5b6568ca689d8561370b0707685d22434faff45"
-  integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==
-  dependencies:
-    ansi-regex "^6.0.1"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -4814,25 +4533,6 @@ ts-node@^10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-ts-node@^10.9.2:
-  version "10.9.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
-  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
-  dependencies:
-    "@cspotcode/source-map-support" "^0.8.0"
-    "@tsconfig/node10" "^1.0.7"
-    "@tsconfig/node12" "^1.0.7"
-    "@tsconfig/node14" "^1.0.0"
-    "@tsconfig/node16" "^1.0.2"
-    acorn "^8.4.1"
-    acorn-walk "^8.1.1"
-    arg "^4.1.0"
-    create-require "^1.1.0"
-    diff "^4.0.1"
-    make-error "^1.1.1"
-    v8-compile-cache-lib "^3.0.1"
-    yn "3.1.1"
-
 tslib@2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
@@ -4909,24 +4609,10 @@ unique-filename@^2.0.0:
   dependencies:
     unique-slug "^3.0.0"
 
-unique-filename@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-3.0.0.tgz#48ba7a5a16849f5080d26c760c86cf5cf05770ea"
-  integrity sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==
-  dependencies:
-    unique-slug "^4.0.0"
-
 unique-slug@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-3.0.0.tgz#6d347cf57c8a7a7a6044aabd0e2d74e4d76dc7c9"
   integrity sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==
-  dependencies:
-    imurmurhash "^0.1.4"
-
-unique-slug@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-4.0.0.tgz#6bae6bb16be91351badd24cdce741f892a6532e3"
-  integrity sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==
   dependencies:
     imurmurhash "^0.1.4"
 
@@ -5114,13 +4800,6 @@ which@^1.2.1:
   dependencies:
     isexe "^2.0.0"
 
-which@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/which/-/which-4.0.0.tgz#cd60b5e74503a3fbcfbf6cd6b4138a8bae644c1a"
-  integrity sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==
-  dependencies:
-    isexe "^3.1.1"
-
 wide-align@^1.1.2, wide-align@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
@@ -5148,15 +4827,6 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
 wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
@@ -5174,15 +4844,6 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
-
-wrap-ansi@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
-  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
-  dependencies:
-    ansi-styles "^6.1.0"
-    string-width "^5.0.1"
-    strip-ansi "^7.0.1"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
- update `@chainsafe/blst` dependency to 2.0.1
- add `validate` optional param to `fromHex` methods

BREAKING CHANGE
- remove async functions
- remove `CoordType` from `fromBytes` methods
- remove `CoordType` from library - the library now abstracts this information
- replace `PointFormat` with `compress` optional param in `toBytes` and `toHex` methods
- remove `PointFormat` from library
- replace flexible `PublicKey | Uint8Array` and `Signature | Uint8Array` parameters with strict input types
  - functional interface operates entirely on `Uint8Array`s, class interface operates on `Signature`, `PublicKey` instances