### PR TITLE
chore: bump actions and enable trustless publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,14 +41,14 @@ jobs:
         with:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
+      - name: Upgrade npm for OIDC
+        run: npm i -g npm@^11.5.1
       - name: Install dependencies
         run: yarn install --non-interactive --frozen-lockfile
       - name: Build
         run: yarn run build
       - name: Publish to npm registry
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,8 @@ on:
 
 permissions:
   id-token: write # Required for OIDC
-  contents: write
+  contents: write # Required to create a Github release
+  pull-requests: write # Required to add tags to pull requests 
 
 jobs:
   tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,17 @@ on:
     branches:
       - 'master'
 
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
 jobs:
   tag:
     name: Check and Tag
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Create tag
         id: tag
         uses: butlerlogic/action-autotag@1.1.2
@@ -31,18 +35,18 @@ jobs:
     if: needs.tag.outputs.tag != ''
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Nodejs
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: yarn install --non-interactive --frozen-lockfile
       - name: Build
         run: yarn run build
       - name: Publish to npm registry
-        run: yarn publish --no-git-tag-version --no-commit-hooks --non-interactive
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Create Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   id-token: write # Required for OIDC
-  contents: read
+  contents: write
 
 jobs:
   tag:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20]
+        node: [22, 24]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node}}
       - name: Install deps


### PR DESCRIPTION
This PR bumps workflow dependencies and adds permissions for enabling OIDC trusted publishing.
Node 24 is the newest LTS and this also bumps it for testing and release.